### PR TITLE
[2/2] chore: add CI job for running integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+jobs:
+  integration_tests:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust
+      run: |
+        rustup update --no-self-update
+        rustc --version
+    - name: Install Miden cargo extension
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: cargo-miden
+    - name: Run integration tests
+      working-directory: integration
+      run: cargo test


### PR DESCRIPTION
The main goal for this CI job is to test PR in this repo.

One thing to note is this CI job will be copied by `cargo miden new` and will end up in the user project. I see it as a good thing.