### PR TITLE
Migrate to the client v0.14

### DIFF
--- a/.claude/skills/miden-concepts/SKILL.md
+++ b/.claude/skills/miden-concepts/SKILL.md
@@ -30,7 +30,7 @@ Key properties:
 ### Accounts
 Each account is an independent smart contract containing:
 - **Code** — Immutable logic compiled from Rust components
-- **Storage** — Up to 255 slots (Value or StorageMap)
+- **Storage** — Up to 255 slots exposed in Rust as `StorageValue<T>` or `StorageMap<K, V>`
 - **Vault** — Holds fungible and non-fungible assets
 - **Nonce** — Incremented with each state change
 - **ID** — Unique identifier (prefix + suffix, 2 Felts)
@@ -58,7 +58,8 @@ A transaction is a **single-account state transition** with 4 phases:
 2. Bob's transaction consumes that note, receiving the tokens
 
 ### Assets
-- **Fungible**: `[amount, 0, faucet_suffix, faucet_prefix]` (1 Word)
+- **SDK shape**: `Asset { key: Word, value: Word }`
+- **Fungible**: asset amount lives in `asset.value[0]`
 - **Non-fungible**: Unique token tied to a faucet account
 - Assets live in account **vaults** and move between accounts via notes
 - Created by **faucet accounts** using `faucet::create_fungible_asset()` or `faucet::mint()`
@@ -66,8 +67,10 @@ A transaction is a **single-account state transition** with 4 phases:
 ### Felt and Word
 - **Felt**: Field element in the Goldilocks prime field (p = 2^64 - 2^32 + 1). The fundamental data unit.
 - **Word**: Array of 4 Felts (32 bytes). Used for cryptographic hashes, storage keys, account IDs.
+- **Current constructors**: `Felt::new`, `Felt::from_u8` / `from_u16` / `from_u32`, `Felt::from_canonical_checked`, `Word::new`, `Word::from([u32; 4])`, `Word::from([Felt; 4])`, `Word::try_from([u64; 4])`
+- **Current accessors**: `felt.as_canonical_u64()`, `word.as_elements()`, `word.into_elements()`, `word.as_bytes()`, `word.to_hex()`
 
-**WARNING**: Felt arithmetic is **modular**. Subtraction wraps around the prime. Always validate with `.as_u64()` before subtracting. See the rust-sdk-pitfalls skill for details.
+**WARNING**: Felt arithmetic is **modular**. Subtraction wraps around the prime. Always validate with `.as_canonical_u64()` before subtracting. See the rust-sdk-pitfalls skill for details.
 
 ## Standard Note Patterns
 
@@ -94,6 +97,6 @@ Contracts are tested locally with **MockChain** (no network needed) and deployed
 
 1. **One account per service** — Each bank, vault, or DEX pool is a separate account
 2. **Notes for communication** — Use deposit/withdraw/request notes instead of direct calls
-3. **Storage for state** — Use `Value` for flags, `StorageMap` for mappings
+3. **Storage for state** — Use `StorageValue<T>` for single slots and `StorageMap<K, V>` for mappings
 4. **Privacy by default** — Choose `NoteType::Public` only when discoverability is needed
 5. **Components for reuse** — Standard wallet, auth, and faucet components compose into accounts

--- a/.claude/skills/rust-sdk-patterns/SKILL.md
+++ b/.claude/skills/rust-sdk-patterns/SKILL.md
@@ -82,7 +82,7 @@ let amount = asset.value[0];
 // Keep the asset key if you need to persist or compare the asset class
 let asset_key = asset.key;
 
-// Add asset to account vault (only from component methods, not note scripts — see pitfall P9)
+// Add asset to account vault (only from component methods, not note scripts — see pitfall P11)
 native_account::add_asset(asset);
 
 // Remove asset from account vault
@@ -135,7 +135,7 @@ use alloc::vec::Vec;
 
 ## Asset Receiving via Component Methods
 
-Note scripts cannot call `native_account::add_asset()` directly (see pitfall P9). The canonical pattern is for an account component to expose a public method that wraps `native_account::add_asset()`, and note scripts call that method via cross-component bindings.
+Note scripts cannot call `native_account::add_asset()` directly (see pitfall P11). The canonical pattern is for an account component to expose a public method that wraps `native_account::add_asset()`, and note scripts call that method via cross-component bindings.
 
 See [miden-bank bank-account deposit()](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for the component side: the `deposit()` method validates the deposit, updates storage, and calls `native_account::add_asset()`.
 

--- a/.claude/skills/rust-sdk-patterns/SKILL.md
+++ b/.claude/skills/rust-sdk-patterns/SKILL.md
@@ -10,7 +10,7 @@ description: Complete guide to writing Miden smart contracts with the Rust SDK. 
 ### Account Component (`#[component]`)
 Defines reusable logic and storage for accounts. Accounts are composed of one or more components.
 
-See [counter-account/src/lib.rs](../../../contracts/counter-account/src/lib.rs) for a working example demonstrating `#[component]`, `StorageMap`, read/write methods, and felt arithmetic.
+See [counter-account/src/lib.rs](../../../contracts/counter-account/src/lib.rs) for a working example demonstrating `#[component]`, typed `StorageMap<Word, Felt>`, `get()`/`set()`, and felt arithmetic.
 
 **Cargo.toml for accounts:** See [counter-account/Cargo.toml](../../../contracts/counter-account/Cargo.toml) for the required `crate-type`, `miden` dependency, `component` metadata, and `project-kind`.
 
@@ -42,8 +42,8 @@ fn run(_arg: Word, account: &mut Account) {
 
 | Type | Usage | Read | Write |
 |------|-------|------|-------|
-| `Value` | Single Word slot (flags, simple state) | `.read() -> Word` | `.write(Word)` |
-| `StorageMap` | Key-value mapping (balances, records) | `.get(&Word) -> Felt` | `.set(Word, Felt)` |
+| `StorageValue<T>` | Single typed slot (flags, counters, IDs) | `.get() -> T` | `.set(T) -> T` |
+| `StorageMap<K, V>` | Typed key-value mapping (balances, records) | `.get(K) -> V` | `.set(K, V) -> V` |
 
 **Storage keys** are always `Word` (4 Felts). Use `Word::from_u64_unchecked(a, b, c, d)` or `Word::from([f0, f1, f2, f3])`.
 
@@ -54,6 +54,7 @@ fn run(_arg: Word, account: &mut Account) {
 | `native_account::` | `add_asset(Asset)`, `remove_asset(Asset)`, `incr_nonce()` | Modify account vault/nonce |
 | `active_account::` | `get_id() -> AccountId`, `get_balance(AccountId) -> Felt` | Query current account |
 | `active_note::` | `get_storage() -> Vec<Felt>`, `get_assets() -> Vec<Asset>`, `get_sender() -> AccountId` | Query note being consumed |
+| `note::` | `build_recipient(Word, Word, Vec<Felt>) -> Recipient` | Build note recipients from serial number, script root, and note storage |
 | `output_note::` | `create(Tag, NoteType, Recipient) -> NoteIdx`, `add_asset(Asset, NoteIdx)` | Create output notes |
 | `faucet::` | `create_fungible_asset(Felt) -> Asset`, `mint(Asset)`, `burn(Asset)` | Asset minting |
 | `tx::` | `get_block_number() -> Felt`, `get_block_timestamp() -> Felt` | Transaction context |
@@ -61,15 +62,27 @@ fn run(_arg: Word, account: &mut Account) {
 
 ## Asset Handling
 
-Fungible asset Word layout: `[amount, 0, faucet_suffix, faucet_prefix]`
+`Asset` is now a two-word value:
 
 **Constructor**: `Asset::new(word)` creates an Asset from a Word.
 
 See [miden-bank bank-account](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for complete asset handling patterns including deposit, withdrawal, and balance tracking.
 
 ```rust
-// Access asset amount
-let amount = asset.inner[0];
+pub struct Asset {
+    pub key: Word,
+    pub value: Word,
+}
+```
+
+For fungible assets, the amount lives in `asset.value[0]`. The asset class / vault identity lives in `asset.key`.
+
+```rust
+// Access fungible amount
+let amount = asset.value[0];
+
+// Keep the asset key if you need to persist or compare the asset class
+let asset_key = asset.key;
 
 // Add asset to account vault (only from component methods, not note scripts — see pitfall P9)
 native_account::add_asset(asset);
@@ -95,15 +108,21 @@ Then import the bindings in your Rust code. See [increment-note/src/lib.rs](../.
 let f = felt!(42);                     // preferred for literals in contract code
 let f = Felt::new(42);                 // construct a Felt from a u64
 let f = Felt::from_u32(42);
-let f = Felt::from_u64_unchecked(42);  // when value is known < field modulus
+let f = Felt::from_canonical_checked(42).unwrap();
 
 // Word from Felts
 let w = Word::from([f0, f1, f2, f3]);
-let w = Word::from_u64_unchecked(0, 0, 0, 1);
 let w = Word::new([f0, f1, f2, f3]);
+let w = Word::from([0_u32, 0, 0, 1]);
+let w = Word::try_from([0_u64, 0, 0, 1]).unwrap();
+
+// Inspect a Word
+let limbs: [Felt; 4] = w.into_elements();
+let bytes: [u8; 32] = w.as_bytes();
+let hex = w.to_hex();
 
 // Felt to u64 (for comparisons and arithmetic safety)
-let n: u64 = f.as_u64();
+let n: u64 = f.as_canonical_u64();
 ```
 
 ## No-std Requirements
@@ -129,6 +148,7 @@ See [miden-bank deposit-note](https://github.com/0xMiden/tutorials/blob/main/exa
 - [ ] `#![no_std]` and `#![feature(alloc_error_handler)]` at top of every contract
 - [ ] `crate-type = ["cdylib"]` in Cargo.toml
 - [ ] Correct `project-kind` in `[package.metadata.miden]`
+- [ ] Typed storage uses `StorageValue<T>` / `StorageMap<K, V>` with `get()` / `set()`
 - [ ] Cross-component deps in both `[package.metadata.miden.dependencies]` and `[package.metadata.component.target.dependencies]`
 - [ ] Felt arithmetic validated before subtraction (see rust-sdk-pitfalls skill)
-- [ ] Felt comparisons use `.as_u64()` (see rust-sdk-pitfalls skill)
+- [ ] Felt comparisons use `.as_canonical_u64()` (see rust-sdk-pitfalls skill)

--- a/.claude/skills/rust-sdk-patterns/SKILL.md
+++ b/.claude/skills/rust-sdk-patterns/SKILL.md
@@ -45,8 +45,6 @@ fn run(_arg: Word, account: &mut Account) {
 | `StorageValue<T>` | Single typed slot (flags, counters, IDs) | `.get() -> T` | `.set(T) -> T` |
 | `StorageMap<K, V>` | Typed key-value mapping (balances, records) | `.get(K) -> V` | `.set(K, V) -> V` |
 
-**Storage keys** are always `Word` (4 Felts). Use `Word::from_u64_unchecked(a, b, c, d)` or `Word::from([f0, f1, f2, f3])`.
-
 ## Native Function Modules
 
 | Module | Key Functions | Purpose |

--- a/.claude/skills/rust-sdk-pitfalls/SKILL.md
+++ b/.claude/skills/rust-sdk-pitfalls/SKILL.md
@@ -40,7 +40,6 @@ if balance > threshold { ... }
 
 // CORRECT for business logic — compare as integers
 if balance.as_canonical_u64() > threshold.as_canonical_u64() { ... }
-- [ ] `Recipient::compute(...)` replaced with `note::build_recipient(...)`
 ```
 
 **Rule**: For quantity/business logic, ALWAYS convert to `.as_canonical_u64()` before using comparison operators.

--- a/.claude/skills/rust-sdk-pitfalls/SKILL.md
+++ b/.claude/skills/rust-sdk-pitfalls/SKILL.md
@@ -17,12 +17,14 @@ let new_balance = current_balance - withdraw_amount;
 // If withdraw_amount > current_balance, new_balance ≈ 2^64 (wraps!)
 
 // SAFE — always validate first
-assert!(current_balance.as_u64() >= withdraw_amount.as_u64(),
-        "Insufficient balance");
+assert!(
+    current_balance.as_canonical_u64() >= withdraw_amount.as_canonical_u64(),
+    "Insufficient balance"
+);
 let new_balance = current_balance - withdraw_amount;
 ```
 
-**Rule**: ALWAYS check `.as_u64()` values before any Felt subtraction.
+**Rule**: ALWAYS check `.as_canonical_u64()` values before any Felt subtraction.
 
 **Max Felt value**: The maximum valid Felt is `p - 1 = 18446744069414584320`, not `u64::MAX` (`18446744073709551615`). Using `u64::MAX` as a sentinel or boundary value causes silent wraparound.
 
@@ -37,10 +39,11 @@ let new_balance = current_balance - withdraw_amount;
 if balance > threshold { ... }
 
 // CORRECT for business logic — compare as integers
-if balance.as_u64() > threshold.as_u64() { ... }
+if balance.as_canonical_u64() > threshold.as_canonical_u64() { ... }
+- [ ] `Recipient::compute(...)` replaced with `note::build_recipient(...)`
 ```
 
-**Rule**: For quantity/business logic, ALWAYS convert to `.as_u64()` before using comparison operators.
+**Rule**: For quantity/business logic, ALWAYS convert to `.as_canonical_u64()` before using comparison operators.
 
 ## P3: Function Argument Limit (4 Words / 16 Felts)
 
@@ -56,23 +59,47 @@ fn process(a: Word, b: Word, c: Word, d: Word, e: Word) { ... } // > 4 Words!
 fn process(a: &Word, b: &Word, c: &Word, d: &Word, e: &Word) { ... }
 ```
 
-## P4: Storage Slot Naming Convention
+## P4: Storage API Is Typed
 
-**Severity**: Medium — causes silent zero returns in tests
+**Severity**: Medium — old examples no longer compile
 
-Storage slot names follow a strict pattern. Getting it wrong returns zero silently.
+The old `Value` / untyped `StorageMap` API is gone. Account storage is now:
 
-**Pattern**: `miden::component::[snake_case(package)]::[field_name]`
+- `StorageValue<T>` for a single typed slot
+- `StorageMap<K, V>` for typed maps
+- `get()` / `set()` methods instead of `.read()` / `.write()`
+- `K: WordKey`, `T: WordValue`, `V: WordValue`
 
-**Conversion rule**: Replace `:` and `-` with `_` in the package name from `[package.metadata.component] package = "..."`.
+```rust
+#[component]
+struct CounterContract {
+    #[storage(description = "single typed slot")]
+    counter: StorageValue<Felt>,
 
-| Package in Cargo.toml | Field | Storage Slot Name |
-|----------------------|-------|-------------------|
-| `miden:counter-account` | `count_map` | `miden::component::miden_counter_account::count_map` |
-| `miden:bank-account` | `balances` | `miden::component::miden_bank_account::balances` |
-| `miden:bank-account` | `initialized` | `miden::component::miden_bank_account::initialized` |
+    #[storage(description = "typed map")]
+    balances: StorageMap<AccountId, Felt>,
+}
+```
 
-## P5: No-std Environment
+If you need custom keys or values, implement `WordKey` / `WordValue` by converting to and from a single `Word`.
+
+## P5: Storage Slot Naming Convention
+
+**Severity**: Medium — causes silent default-value reads in tests
+
+Storage slot names follow a strict pattern. Getting it wrong often returns the default value silently.
+
+**Pattern**: `[component_package_or_name]::[snake_case(component_struct)]::[field_name]`
+
+**Conversion rule**: Replace characters outside `[A-Za-z0-9_]` with `_` in the package or component name. The package comes from `[package.metadata.component] package = "..."`, with any `@version` suffix ignored.
+
+| Package in Cargo.toml | Component Struct | Field | Storage Slot Name |
+|----------------------|------------------|-------|-------------------|
+| `miden:counter-account` | `CounterContract` | `count_map` | `miden_counter_account::counter_contract::count_map` |
+| `miden:bank-account` | `BankAccount` | `balances` | `miden_bank_account::bank_account::balances` |
+| `miden:bank-account` | `BankAccount` | `initialized` | `miden_bank_account::bank_account::initialized` |
+
+## P6: No-std Environment
 
 **Severity**: Medium -- causes compilation errors
 
@@ -86,31 +113,49 @@ extern crate alloc;
 use alloc::vec::Vec;
 ```
 
-## P6: Asset Word Layout
+## P7: Asset ABI Is Two Words, Not One
 
-**Severity**: Medium — creates invalid assets
+**Severity**: Medium — old `asset.inner[...]` code is stale
 
-Fungible assets have a specific Word layout. Getting the order wrong creates invalid assets or reads wrong amounts.
+`Asset` is now:
 
-```
-Asset Word: [amount, 0, faucet_suffix, faucet_prefix]
-              [0]   [1]      [2]            [3]
+```rust
+pub struct Asset {
+    pub key: Word,
+    pub value: Word,
+}
 ```
 
 ```rust
-// Reading amount from an asset
-let amount = asset.inner[0];
+// Reading the amount from a fungible asset
+let amount = asset.value[0];
 
-// Constructing asset key for storage (including faucet identity)
-let key = Word::from([
-    depositor.prefix,
-    depositor.suffix,
-    asset.inner[3],  // faucet prefix
-    asset.inner[2],  // faucet suffix
-]);
+// Persisting or comparing the asset class
+let asset_key = asset.key;
 ```
 
-## P7: P2ID Note Root Hardcoding
+Do not assume the old single-word asset layout. Use `asset.key` and `asset.value`, or protocol helpers, instead of reconstructing from old `asset.inner[...]` offsets.
+
+## P8: `Recipient::compute` Was Removed
+
+**Severity**: Medium — causes compilation errors after upgrading
+
+Building recipients now goes through the note binding:
+
+```rust
+extern crate alloc;
+use alloc::vec;
+
+let recipient = note::build_recipient(
+    serial_num,
+    script_root,
+    vec![recipient_id.suffix, recipient_id.prefix],
+);
+```
+
+`active_note::get_inputs()` also became `active_note::get_storage()`.
+
+## P9: P2ID Note Root Hardcoding
 
 **Severity**: Low-Medium — breaks after miden-standards updates
 
@@ -120,12 +165,15 @@ For any note that is being created within the compiler code, the MAST root diges
 
 ```rust
 fn p2id_note_root() -> Digest {
-    Digest::from_word(Word::new([
-        Felt::from_u64_unchecked(13362761878458161062),
-        Felt::from_u64_unchecked(15090726097241769395),
-        Felt::from_u64_unchecked(444910447169617901),
-        Felt::from_u64_unchecked(3558201871398422326),
-    ]))
+    Digest::from_word(
+        Word::try_from([
+            13362761878458161062_u64,
+            15090726097241769395_u64,
+            444910447169617901_u64,
+            3558201871398422326_u64,
+        ])
+        .unwrap(),
+    )
 }
 ```
 
@@ -163,17 +211,3 @@ See [miden-bank deposit-note](https://github.com/0xMiden/tutorials/blob/main/exa
 
 Note inputs (`active_note::get_storage()`) are baked at note creation time and cannot be modified after creation. Design note input layouts carefully before deployment.
 
-## Quick Reference
-
-| Pitfall | One-Line Rule |
-|---------|--------------|
-| P1 Felt arithmetic | Always `.as_u64()` before subtraction |
-| P2 Felt comparison | Always `.as_u64()` for `<` `>` `<=` `>=` in business logic |
-| P3 Arg limit | Max 4 Words per function — pass by reference |
-| P4 Storage names | `miden::component::pkg_name::field` (underscores) |
-| P5 No-std | `#![no_std]` + `#![feature(alloc_error_handler)]` |
-| P6 Asset layout | `[amount, 0, suffix, prefix]` |
-| P7 P2ID root | Verify digest after dependency updates; use `NoteType::from(felt!(2))` for private |
-| P8 NoteType | No named variants in contracts — use `NoteType::from(felt!(n))` |
-| P9 Note ↛ native_account | Note scripts must call component methods, not `native_account::` |
-| P10 Note inputs | Immutable after creation — design layouts upfront |

--- a/.claude/skills/rust-sdk-pitfalls/SKILL.md
+++ b/.claude/skills/rust-sdk-pitfalls/SKILL.md
@@ -153,8 +153,6 @@ let recipient = note::build_recipient(
 );
 ```
 
-`active_note::get_inputs()` also became `active_note::get_storage()`.
-
 ## P9: P2ID Note Root Hardcoding
 
 **Severity**: Low-Medium — breaks after miden-standards updates

--- a/.claude/skills/rust-sdk-pitfalls/SKILL.md
+++ b/.claude/skills/rust-sdk-pitfalls/SKILL.md
@@ -178,9 +178,9 @@ fn p2id_note_root() -> Digest {
 
 **Mitigation**: Use `P2idNote::script_root()` from miden-standards if available, or verify the hardcoded root matches the current version after dependency updates.
 
-**NoteType for P2ID**: P2ID output notes created in contract code should use the private note type value via `NoteType::from(felt!(2))` (see P8). Using the public note type triggers an opaque "missing details in advice provider" error at execution time. See [miden-bank withdraw](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for the working pattern.
+**NoteType for P2ID**: P2ID output notes created in contract code should use the private note type value via `NoteType::from(felt!(2))` (see P10). Using the public note type triggers an opaque "missing details in advice provider" error at execution time. See [miden-bank withdraw](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for the working pattern.
 
-## P8: NoteType Variants Unavailable in Compiler SDK
+## P10: NoteType Variants Unavailable in Compiler SDK
 
 **Severity**: Medium -- causes compilation errors
 
@@ -194,7 +194,7 @@ Named enum variants (`NoteType::Private`, `NoteType::Public`, `NoteType::Encrypt
 
 See [miden-bank bank-account](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for `NoteType::from(note_type)` usage.
 
-## P9: Note Scripts Cannot Call Native Account Functions
+## P11: Note Scripts Cannot Call Native Account Functions
 
 **Severity**: High -- causes runtime failures
 
@@ -202,9 +202,8 @@ Note scripts cannot call `native_account::add_asset()` or other `native_account:
 
 See [miden-bank deposit-note](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/deposit-note/src/lib.rs) for the correct pattern: the note script calls `bank_account::deposit()`, which internally calls `native_account::add_asset()`.
 
-## P10: Note Inputs Are Immutable After Creation
+## P12: Note Inputs Are Immutable After Creation
 
 **Severity**: Low -- causes incorrect architecture
 
 Note inputs (`active_note::get_storage()`) are baked at note creation time and cannot be modified after creation. Design note input layouts carefully before deployment.
-

--- a/.claude/skills/rust-sdk-source-guide/SKILL.md
+++ b/.claude/skills/rust-sdk-source-guide/SKILL.md
@@ -84,8 +84,8 @@ git clone --depth 1 --branch main https://github.com/0xMiden/compiler.git ../com
 # Required: contains client API for deployment and chain interaction
 git clone --depth 1 --branch main https://github.com/0xMiden/miden-client.git ../miden-client
 
-# Recommended: complete working banking app with advanced patterns
-git clone --branch main https://github.com/keinberger/miden-bank.git ../miden-bank
+# Recommended: complete working banking app with advanced patterns in the `examples/miden-bank` folder of the tutorials repo
+git clone --branch main https://github.com/0xMiden/tutorials.git ../tutorials
 ```
 
 **Note**: These commands clone the stable `main` branch. Only use `--branch next` if the user explicitly requests the experimental/upcoming version of the compiler or source repos.

--- a/.claude/skills/rust-sdk-source-guide/SKILL.md
+++ b/.claude/skills/rust-sdk-source-guide/SKILL.md
@@ -29,7 +29,6 @@ This is the single highest-leverage practice for AI-assisted Miden development.
    - `Recipient::compute(...)` -> `note::build_recipient(...)`
    - `Value` -> `StorageValue<T>`
    - `StorageMap` -> `StorageMap<K, V>`
-   - `active_note::get_inputs()` -> `active_note::get_storage()`
 3. Search the source repos for a working example of the pattern that failed
 4. Adapt the working pattern to your use case
 5. Rebuild
@@ -163,7 +162,8 @@ Accounts can include standard components (BasicWallet, authentication) alongside
 Create output notes (like P2ID) from within contract code. Requires building a recipient with `note::build_recipient(serial_num, script_root, storage)` and then using `output_note::create(...)`. The `miden-bank/` withdraw pattern demonstrates this end-to-end.
 
 ### Note Storage Protocol
-Pass structured data to notes via `Vec<Felt>` storage. Define your storage layout, document the field ordering, and parse it with `active_note::get_storage()` in the `#[note_script]` function. Attached assets are separate and should be read with `active_note::get_assets()`.
+Notes receive storage data as `Vec<Felt>` which is deserialized into the note object. In the `#[note_script]` method the `self` is deserialized from the note storage (`active_note::get_storage()`).
+Attached assets are separate and should be read with `active_note::get_assets()`.
 
 ### Atomic Swaps
 The standard SwapNote in `miden-base/` creates a payback P2ID note automatically when consumed. Explore the SwapNote builder to understand tag construction, storage layout, and the payback mechanism.

--- a/.claude/skills/rust-sdk-source-guide/SKILL.md
+++ b/.claude/skills/rust-sdk-source-guide/SKILL.md
@@ -24,11 +24,17 @@ This is the single highest-leverage practice for AI-assisted Miden development.
 
 **Build loop**: After every contract edit, run `cargo miden build --manifest-path contracts/<name>/Cargo.toml --release`. The project's build hook does this automatically. If the build fails:
 1. Read the error message
-2. Search the source repos for a working example of the pattern that failed
-3. Adapt the working pattern to your use case
-4. Rebuild
+2. Translate obvious SDK migration errors first:
+   - `.as_u64()` -> `.as_canonical_u64()`
+   - `Recipient::compute(...)` -> `note::build_recipient(...)`
+   - `Value` -> `StorageValue<T>`
+   - `StorageMap` -> `StorageMap<K, V>`
+   - `active_note::get_inputs()` -> `active_note::get_storage()`
+3. Search the source repos for a working example of the pattern that failed
+4. Adapt the working pattern to your use case
+5. Rebuild
 
-**Test loop**: Write tests alongside contracts. Run with `cargo test -p integration --release`. When tests fail:
+**Test loop**: Write tests alongside contracts. Run full repo checks with `cargo make test` (or `cargo test -p integration --release` for a faster integration-only loop). When tests fail:
 1. Check the error — is it a build error, a runtime assertion, or a proof failure?
 2. For assertion failures: check felt arithmetic (modular wrapping) and storage slot naming
 3. For unexpected behavior: compare your code against the closest working example in source repos
@@ -122,7 +128,7 @@ Contains the Rust API for deploying contracts and interacting with the Miden net
 A complete banking application built with the Rust SDK. Demonstrates advanced patterns that go beyond the basic skills.
 
 - Multiple contract types working together (account, deposit note, withdraw note, tx script)
-- Advanced patterns: StorageMap + Value composition, felt arithmetic safety, cross-component calls, P2ID output note creation from within contracts
+- Advanced patterns: `StorageMap<K, V>` + `StorageValue<T>` composition, felt arithmetic safety, cross-component calls, P2ID output note creation from within contracts
 - Multi-step integration tests with output note verification
 
 **Explore when**: Building multi-contract applications, understanding how pieces fit together, seeing a complete working app end-to-end.
@@ -133,12 +139,12 @@ A complete banking application built with the Rust SDK. Demonstrates advanced pa
 
 | Building This | Explore These Repos | What to Look For |
 |---|---|---|
-| Account component with storage | `compiler/` examples, `miden-bank/` contracts | StorageMap/Value patterns, pub method signatures |
-| Note script | `compiler/` examples, `miden-bank/` contracts | `#[note_script]` pattern, cross-component calls, note inputs parsing |
+| Account component with storage | `compiler/` examples, `miden-bank/` contracts | `StorageMap<K, V>` / `StorageValue<T>` patterns, pub method signatures |
+| Note script | `compiler/` examples, `miden-bank/` contracts | `#[note_script]` pattern, cross-component calls, note storage parsing |
 | Transaction script | `compiler/` examples, `miden-bank/` contracts | `#[tx_script]` pattern, Account binding import |
 | Authentication component | `compiler/` examples | Auth component patterns (NoAuth, Falcon512, ECDSA) |
 | Faucet (token minting) | `compiler/` examples | BasicFungibleFaucet example, mint/burn pattern |
-| P2ID output notes | `miden-bank/` contracts, `miden-base/` standards (data layouts) | Recipient computation, script root, output_note creation |
+| P2ID output notes | `miden-bank/` contracts, `miden-base/` standards (data layouts) | `note::build_recipient`, script root, `output_note` creation |
 | Swap notes | `miden-base/` standards (data layouts) | SwapNote data layout, tag construction, payback flow |
 | Multi-step tests | `miden-bank/` integration tests | Init → operate → verify flow, output note verification |
 | Client deployment | `miden-client/` | TransactionRequestBuilder, sync, submit patterns |
@@ -154,10 +160,10 @@ These patterns go beyond what the basic skills cover. For each, the source repos
 Accounts can include standard components (BasicWallet, authentication) alongside custom logic at account creation time. Standard components are MASM-only (not callable from Rust), but they are composed into accounts via the testing/deployment infrastructure. The `compiler/` examples show how to compose accounts with multiple components.
 
 ### Output Note Creation from Contracts
-Create output notes (like P2ID) from within contract code. Requires computing a Recipient hash from serial number, script root, and inputs. The `miden-bank/` withdraw pattern demonstrates this end-to-end.
+Create output notes (like P2ID) from within contract code. Requires building a recipient with `note::build_recipient(serial_num, script_root, storage)` and then using `output_note::create(...)`. The `miden-bank/` withdraw pattern demonstrates this end-to-end.
 
-### Note Inputs Protocol
-Pass structured data to notes via `Vec<Felt>` inputs. Define your input layout, document the field ordering, and parse inputs in the `#[note_script]` function. The `miden-bank/` withdraw-request-note demonstrates parsing 10 Felts into asset, serial number, tag, and note type.
+### Note Storage Protocol
+Pass structured data to notes via `Vec<Felt>` storage. Define your storage layout, document the field ordering, and parse it with `active_note::get_storage()` in the `#[note_script]` function. Attached assets are separate and should be read with `active_note::get_assets()`.
 
 ### Atomic Swaps
 The standard SwapNote in `miden-base/` creates a payback P2ID note automatically when consumed. Explore the SwapNote builder to understand tag construction, storage layout, and the payback mechanism.

--- a/.claude/skills/rust-sdk-testing-patterns/SKILL.md
+++ b/.claude/skills/rust-sdk-testing-patterns/SKILL.md
@@ -15,16 +15,18 @@ See [counter_test.rs](../../../integration/tests/counter_test.rs) for a complete
 
 ### 1. Initialize MockChain Builder
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) line 17 for the pattern: `let mut builder = MockChain::builder();`
+See [counter_test.rs](../../../integration/tests/counter_test.rs) line 21 for the pattern: `let mut builder = MockChain::builder();`
 
 ### 2. Create Sender/Wallet Accounts
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) line 20 for the basic wallet pattern. For wallets with pre-funded assets, use `builder.add_existing_wallet_with_assets(Auth::BasicAuth, [FungibleAsset::new(faucet.id(), 100)?.into()])`.
+See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 24-26 for the basic wallet pattern. For wallets with pre-funded assets, use `builder.add_existing_wallet_with_assets(Auth::BasicAuth { auth_scheme: AuthSchemeId::Falcon512Poseidon2 }, [FungibleAsset::new(faucet.id(), 100)?.into()])`.
 
 ### 3. Set Up Faucets (for fungible assets)
 ```rust
 let faucet = builder.add_existing_basic_faucet(
-    Auth::BasicAuth,
+    Auth::BasicAuth {
+        auth_scheme: AuthSchemeId::Falcon512Poseidon2,
+    },
     "TOKEN",     // token symbol
     1000,        // max supply
     Some(10),    // total_issuance (None for 0)
@@ -33,7 +35,7 @@ let faucet = builder.add_existing_basic_faucet(
 
 ### 4. Build Contracts
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 23-30 for the pattern using `build_project_in_dir`.
+See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 29-35 for the pattern using `build_project_in_dir`.
 
 ### 5. Create Account with Storage
 
@@ -48,45 +50,60 @@ Examples:
 
 Rule: Replace characters outside `[A-Za-z0-9_]` with `_` in the package or component name.
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 33-51 for a complete StorageMap example with `StorageSlotName`, `StorageSlot::with_map`, `AccountCreationConfig`, and `create_testing_account_from_package`.
+See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 38-54 for the current pattern: populate `InitStorageData`, build the component from the compiled package, then register the account with `builder.add_account_from_builder(...)`.
+
+```rust
+let counter_storage_slot = counter_storage_slot()?;
+let mut init_storage_data = InitStorageData::default();
+init_storage_data.insert_map_entry(counter_storage_slot.clone(), COUNTER_STORAGE_KEY, 0_u64)?;
+
+let counter_component =
+    AccountComponent::from_package(&contract_package, &init_storage_data)?;
+let counter_account = builder.add_account_from_builder(
+    Auth::BasicAuth {
+        auth_scheme: AuthSchemeId::Falcon512Poseidon2,
+    },
+    AccountBuilder::new([3_u8; 32])
+        .account_type(AccountType::RegularAccountImmutableCode)
+        .storage_mode(AccountStorageMode::Public)
+        .with_component(counter_component),
+    AccountState::Exists,
+)?;
+```
 
 For a single-value contract slot (paired with `StorageValue<T>` on-chain) instead of a map:
 ```rust
-let value_slot_name = StorageSlotName::new("miden_bank_account::bank_account::initialized").unwrap();
-let storage_slots = vec![StorageSlot::with_value(
-    value_slot_name.clone(),
-    Word::default(),
-)];
+let mut init_storage_data = InitStorageData::default();
+init_storage_data.insert_value(
+    "miden_bank_account::bank_account::initialized",
+    0_u64,
+)?;
 ```
 
 ### 6. Create Notes
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 54-58 for basic note creation with `create_testing_note_from_package`.
+See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 56-64 for basic note creation with `RandomCoin`, `NoteScript::from_package`, and `NoteBuilder`.
 
 For notes with assets and inputs:
 ```rust
-use miden_client::note::NoteAssets;
-use miden_client::asset::FungibleAsset;
+use miden_client::{asset::FungibleAsset, crypto::RandomCoin, note::NoteScript, Felt};
+use miden_standards::testing::note::NoteBuilder;
 
-let note_assets = NoteAssets::new(vec![FungibleAsset::new(faucet.id(), 50)?.into()])?;
-let note = create_testing_note_from_package(
-    note_package.clone(),
-    sender.id(),
-    NoteCreationConfig {
-        assets: note_assets,
-        inputs: vec![Felt::new(42), Felt::new(0)],
-        ..Default::default()
-    },
-)?;
+let mut note_rng = RandomCoin::new(NoteScript::from_package(note_package.as_ref())?.root());
+let note = NoteBuilder::new(sender.id(), &mut note_rng)
+    .package((*note_package).clone())
+    .add_assets([FungibleAsset::new(faucet.id(), 50)?.into()])
+    .note_storage([Felt::new(42), Felt::new(0)])?
+    .build()?;
 ```
 
 ### 7. Add to MockChain and Build
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 61-65 for adding accounts, notes, and building the mock chain.
+See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 66-70 for seeding the note and building the mock chain. `add_account_from_builder(...)` has already registered the account in the builder, so at this stage you usually only need to add notes.
 
 ### 8. Execute Transaction
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 67-79 for the full execution flow: `build_tx_context` -> `execute()` -> `apply_delta()` -> `add_pending_executed_transaction()` -> `prove_next_block()`.
+See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 73-82 for the full execution flow: `build_tx_context` -> `execute()` -> `add_pending_executed_transaction()` -> `prove_next_block()`. For the default MockChain flow, do not call `apply_delta()`; fetch refreshed state from `mock_chain.committed_account(...)` after the block is proven.
 
 ### 9. Execute with Transaction Script
 ```rust
@@ -99,33 +116,35 @@ let tx_script_package = Arc::new(build_project_in_dir(
 let program = tx_script_package.unwrap_program();
 let tx_script = TransactionScript::new((*program).clone());
 
-let tx_context = mock_chain
-    .build_tx_context(account.id(), &[], &[])?
+let executed = mock_chain
+    .build_tx_context(account.clone(), &[], &[])?
     .tx_script(tx_script)
-    .build()?;
+    .build()?
+    .execute()
+    .await?;
 
-let executed = tx_context.execute().await?;
-account.apply_delta(executed.account_delta())?;
 mock_chain.add_pending_executed_transaction(&executed)?;
 mock_chain.prove_next_block()?;
+
+let updated_account = mock_chain.committed_account(account.id())?;
 ```
 
 ### 10. Verify Storage State
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 82-92 for reading a StorageMap value and asserting on the result.
+See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 84-96 for reading the committed account state and asserting on the result.
 
 ### 11. Verify Output Notes
 
 **Important**: `add_output_note()` is only available on `MockChainBuilder` (before `build()`) — use it to seed the chain with existing notes. To verify output notes from a transaction, use `extend_expected_output_notes()` on `TxContextBuilder`:
 
 ```rust
-use miden_client::note::{Note, NoteAssets, NoteMetadata, NoteRecipient};
+use miden_client::{note::{Note, NoteAssets, NoteMetadata, NoteRecipient}, transaction::RawOutputNote};
 
 let expected_note = Note::new(expected_assets, expected_metadata, expected_recipient);
 
 let tx_context = mock_chain
     .build_tx_context(account.id(), &[note.id()], &[])?
-    .extend_expected_output_notes(vec![OutputNote::Full(expected_note)])
+    .extend_expected_output_notes(vec![RawOutputNote::Full(expected_note)])
     .build()?;
 
 // execute() will verify output notes match
@@ -134,11 +153,13 @@ let executed = tx_context.execute().await?;
 
 ## Multi-Transaction Test Pattern
 
-For contracts requiring initialization before use, each step needs its own execute → `apply_delta()` → `add_pending_executed_transaction()` → `prove_next_block()` cycle.
+For contracts requiring initialization before use, each step usually needs its own `execute()` → `add_pending_executed_transaction()` → `prove_next_block()` cycle. Fetch the committed account or note state from `mock_chain` between steps before building the next context.
+
+`apply_delta()` is only needed in advanced same-block tests that intentionally reuse an in-memory `Account` across multiple transactions before proving the block.
 
 See [miden-bank withdraw_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/withdraw_test.rs) for a complete multi-transaction test demonstrating: initialize bank → deposit assets → withdraw assets (3 sequential transactions with state verification between each step).
 
-See [miden-bank deposit_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/deposit_test.rs) for asset-bearing note construction using `NoteAssets::new()` with `FungibleAsset`.
+See [miden-bank deposit_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/deposit_test.rs) for an end-to-end asset-bearing note test.
 
 ## MockChain Block Numbering
 
@@ -146,20 +167,18 @@ Genesis is block 0. Each `prove_next_block()` advances the block number by 1. In
 
 ## Note Construction
 
-Always use `create_testing_note_from_package` (or mirror its logic with `.masp` package files) for creating notes in tests. Manually constructed notes may fail with a "private notes cannot be converted" error. See [counter_test.rs](../../../integration/tests/counter_test.rs) for the working pattern.
+Prefer `NoteBuilder` (or mirror its logic with compiled `.masp` package files) for creating notes in tests. Start from `NoteBuilder::new(sender.id(), &mut note_rng)`, then configure `.package(...)`, optional `.add_assets(...)`, optional `.note_storage(...)`, and finally `.build()`. See [counter_test.rs](../../../integration/tests/counter_test.rs) for the working pattern.
 
 ## Asset-Bearing Note Example
 
 To create a note that carries fungible assets in tests:
 
 1. Create a `FungibleAsset` from a faucet ID and amount.
-2. Wrap it in `NoteAssets::new(vec![Asset::Fungible(fungible_asset)])`.
-3. Pass the `NoteAssets` into `NoteCreationConfig { assets: note_assets, ..Default::default() }`.
-4. Use `create_testing_note_from_package` as usual.
+2. Seed a `RandomCoin` from `NoteScript::from_package(note_package.as_ref())?.root()`.
+3. Pass the asset into `NoteBuilder::add_assets(...)` and any note inputs into `note_storage(...)`.
+4. Finish with `.package((*note_package).clone()).build()?`.
 
 The faucet must be set up first (see Step 3) and the sender wallet must hold sufficient assets (see Step 2).
-
-See [miden-bank deposit_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/deposit_test.rs) lines 56-70 for the complete working pattern, including `FungibleAsset::new()`, `NoteAssets::new()`, and `NoteCreationConfig` usage.
 
 ## Key Dependencies
 
@@ -170,7 +189,8 @@ See [integration/Cargo.toml](../../../integration/Cargo.toml) for the current de
 - [ ] Test function is `async` and uses `#[tokio::test]`
 - [ ] Storage slot names follow `package_or_name::component_struct::field_name` pattern
 - [ ] All contracts built before account/note creation
-- [ ] `apply_delta()` called after each `execute()`
+- [ ] Account storage seeded via `InitStorageData`
 - [ ] `prove_next_block()` called after `add_pending_executed_transaction()`
-- [ ] Notes added to `MockChainBuilder` via `add_output_note(OutputNote::Full(...))` (before `build()`)
+- [ ] Post-block assertions read state from `mock_chain.committed_account(...)` or other committed chain views
+- [ ] Notes added to `MockChainBuilder` via `add_output_note(RawOutputNote::Full(...))` before `build()`
 - [ ] Faucet set up before creating assets

--- a/.claude/skills/rust-sdk-testing-patterns/SKILL.md
+++ b/.claude/skills/rust-sdk-testing-patterns/SKILL.md
@@ -39,20 +39,20 @@ See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 23-30 fo
 
 **Storage slot naming convention** (CRITICAL):
 ```
-miden::component::[snake_case(package.metadata.component.package)]::[field_name]
+[component_package_or_name]::[snake_case(component_struct)]::[field_name]
 ```
 
 Examples:
-- Package `miden:counter-account`, field `count_map` -> `miden::component::miden_counter_account::count_map`
-- Package `miden:bank-account`, field `balances` -> `miden::component::miden_bank_account::balances`
+- Package `miden:counter-account`, component `CounterContract`, field `count_map` -> `miden_counter_account::counter_contract::count_map`
+- Package `miden:bank-account`, component `BankAccount`, field `balances` -> `miden_bank_account::bank_account::balances`
 
-Rule: Replace colons and hyphens with underscores in the package name.
+Rule: Replace characters outside `[A-Za-z0-9_]` with `_` in the package or component name.
 
 See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 33-51 for a complete StorageMap example with `StorageSlotName`, `StorageSlot::with_map`, `AccountCreationConfig`, and `create_testing_account_from_package`.
 
-For a Value slot (single Word) instead of a StorageMap:
+For a single-value contract slot (paired with `StorageValue<T>` on-chain) instead of a map:
 ```rust
-let value_slot_name = StorageSlotName::new("miden::component::miden_bank_account::initialized").unwrap();
+let value_slot_name = StorageSlotName::new("miden_bank_account::bank_account::initialized").unwrap();
 let storage_slots = vec![StorageSlot::with_value(
     value_slot_name.clone(),
     Word::default(),
@@ -168,7 +168,7 @@ See [integration/Cargo.toml](../../../integration/Cargo.toml) for the current de
 ## Validation Checklist
 
 - [ ] Test function is `async` and uses `#[tokio::test]`
-- [ ] Storage slot names follow `miden::component::package_name::field_name` pattern
+- [ ] Storage slot names follow `package_or_name::component_struct::field_name` pattern
 - [ ] All contracts built before account/note creation
 - [ ] `apply_delta()` called after each `execute()`
 - [ ] `prove_next_block()` called after `add_pending_executed_transaction()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Always build contracts before running tests — tests compile contracts via `bui
 ## SDK Quick Reference
 
 See the working examples in this project:
-- `contracts/counter-account/src/lib.rs` — Account component with StorageMap
+- `contracts/counter-account/src/lib.rs` — Account component with typed `StorageMap<Word, Felt>`
 - `contracts/increment-note/src/lib.rs` — Note script with cross-component call
 - `integration/tests/counter_test.rs` — MockChain integration test
 
@@ -35,11 +35,14 @@ See the working examples in this project:
 
 **Felt arithmetic is modular (SECURITY CRITICAL)**: Subtraction wraps around the field modulus instead of panicking. ALWAYS validate before subtraction:
 ```rust
-assert!(current.as_u64() >= amount.as_u64(), "Insufficient balance");
+assert!(
+    current.as_canonical_u64() >= amount.as_canonical_u64(),
+    "Insufficient balance"
+);
 let result = current - amount;
 ```
 
-**Felt comparisons are misleading for quantity logic**: `<`, `>`, `<=`, `>=` on Felt compare field elements, which differs from natural number ordering. For business logic (balances, amounts, counts), ALWAYS convert first: `a.as_u64() < b.as_u64()`
+**Felt comparisons are misleading for quantity logic**: `<`, `>`, `<=`, `>=` on Felt compare field elements, which differs from natural number ordering. For business logic (balances, amounts, counts), ALWAYS convert first: `a.as_canonical_u64() < b.as_canonical_u64()`
 
 **No-std required**: All contracts must use `#![no_std]` and `#![feature(alloc_error_handler)]`. For heap allocation, use `extern crate alloc;` and `BumpAlloc`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,16 +395,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -485,7 +485,7 @@ dependencies = [
  "midenc-log",
  "midenc-session",
  "path-absolutize",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "tempfile",
@@ -510,7 +510,7 @@ checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "thiserror",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -551,7 +551,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -659,7 +659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -715,6 +715,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -804,7 +813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1057,6 +1066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,9 +1100,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1499,9 +1519,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1514,7 +1534,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1611,9 +1630,9 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1655,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8062b737e5389949f477d4760a2ebbff0c366f97798f2419b8d8f366363d3342"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1725,9 +1744,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1755,7 +1774,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1813,9 +1832,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1913,7 +1932,7 @@ dependencies = [
  "paste",
  "rustc-hash",
  "serde",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "smallvec",
  "thiserror",
  "toml 0.9.12+spec-1.1.0",
@@ -2086,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98863d46f0f288b03f52a4591230b6ddded2b2110b4e0f9268d4b6f19efe49ba"
+checksum = "73a12734b3bf5e8c88580c4c173368865d1efd6f51f48365df76b59f12d8dc53"
 dependencies = [
  "alloy-sol-types",
  "fs-err",
@@ -2107,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5322d00bef8b19f4cd3415da2533a87c8860c7d9b80043d6cce0f184b40c5fff"
+checksum = "d15646ebc95906b2a7cb66711d1e184f53fd6edc2605730bbcf0c2a129f792cf"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2120,24 +2139,26 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ece22da0cbf350e4a2939a07eaa3200445e42e47ce1b1ee6538723b6b40a4d4"
+checksum = "ae6013b3a390e0dcb29242f4480a7727965887bbf0903466c88f362b4cb20c0e"
 dependencies = [
  "env_logger",
  "log",
  "miden-assembly-syntax",
  "miden-core",
  "miden-mast-package",
+ "miden-package-registry",
+ "miden-project",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d84a0e14ce66e76497a6771f3e360eb85557f2417ea22db279d54c1238ffafde"
+checksum = "996156b8f7c5fe6be17dea71089c6d7985c2dec1e3a4fec068b1dfc690e25df5"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -2152,16 +2173,17 @@ dependencies = [
  "proptest-derive",
  "regex",
  "rustc_version 0.4.1",
- "semver 1.0.27",
+ "semver 1.0.28",
+ "serde",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-block-prover"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710309c899f329e92853b1e396d01d6d0876dc5a95555b786cf7e6c93eae5bd"
+checksum = "334340b0b2e6993f6b71af359a77cf8730c4a19ac366f77aee734a5faa993897"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -2170,7 +2192,8 @@ dependencies = [
 [[package]]
 name = "miden-client"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-client#5af8086eb03881fcd9ac6b853f34aea660cf8560"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49957f76717961769c911237113bb9c1841c3b13970c15ca09a0ae639c33fc45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2205,7 +2228,8 @@ dependencies = [
 [[package]]
 name = "miden-client-sqlite-store"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-client#5af8086eb03881fcd9ac6b853f34aea660cf8560"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab146099a4bf8319f5cac47e110eca7d3e3caa9d2fc354693458f905f4750a7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2222,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf4f5601b0d669aa125cce3bba4b98f2c8df729e2d53e66777429ac5f53e228"
+checksum = "fdec54a321cdf3d23e9ef615e91cb858038c6b4d4202507bdec048fc6d7763e4"
 dependencies = [
  "derive_more",
  "itertools",
@@ -2238,20 +2262,22 @@ dependencies = [
  "num-traits",
  "proptest",
  "proptest-derive",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82595fabb062315c32f6fc11c31755d3e5c6f8bc8c67d35154a067397d65b1de"
+checksum = "621e8fa911a790bcf3cd3aedce80bc10922a19d6181f08ff3ca078f955cff70b"
 dependencies = [
  "env_logger",
  "fs-err",
  "miden-assembly",
  "miden-core",
  "miden-crypto",
+ "miden-package-registry",
  "miden-processor",
  "miden-utils-sync",
  "thiserror",
@@ -2312,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ef08bafef275f0d6a15108108b3f6df6642772e0a1c05e102cb7e96841e888"
+checksum = "d6e50274d11c80b901cf6c90362de8c98c8c8ad6030c80624d683b63d899a0fb"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2324,7 +2350,7 @@ dependencies = [
  "miden-utils-sync",
  "paste",
  "serde",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "thiserror",
 ]
 
@@ -2357,14 +2383,15 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b24d09fda64e0751f943ac616643342b05a47d626e2ee0040b902eff3c924e"
+checksum = "bc8b2e3447fcde1f0e6b76e5219f129517639772cb02ca543177f0584e315288"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",
+ "serde",
  "thiserror",
 ]
 
@@ -2406,8 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-node?rev=c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8#c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c78309c58cbffd5fd92c944d6f7f3ed6d59340587c74d4eab4e6edf9e31e8d3"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -2429,10 +2457,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-processor"
-version = "0.22.0"
+name = "miden-package-registry"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba53ff06ef0affa0c3fb13e7e2ef5bde99f96eebcec8c360c6658050480ef676"
+checksum = "969ba3942052e52b3968e34dbd1c52c707e75777ee42ebdae2c8f57af56cf6cf"
+dependencies = [
+ "miden-assembly-syntax",
+ "miden-core",
+ "miden-mast-package",
+ "pubgrub",
+ "serde",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ec6cecbf22bd92b73a931ee80b424e46b8b7cdf4f2f3c364c25c5c15d2840da"
 dependencies = [
  "itertools",
  "miden-air",
@@ -2448,10 +2491,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-protocol"
-version = "0.14.0"
+name = "miden-project"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c30a20ea30071544a827d0daa12e343e444c1e314d1a4560c43f2d6c7b43c6"
+checksum = "3840520c01881534fbbceb6b3687ec1c407fbaf310a35ce415fd3510abc52fdb"
+dependencies = [
+ "miden-assembly-syntax",
+ "miden-core",
+ "miden-mast-package",
+ "miden-package-registry",
+ "serde",
+ "serde-untagged",
+ "thiserror",
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "miden-protocol"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595b3d43ceb562d05e248a6c52bdc2992dc270b60d6d0e8c0a6480aa30672b8e"
 dependencies = [
  "bech32",
  "fs-err",
@@ -2470,18 +2529,18 @@ dependencies = [
  "rand_chacha",
  "rand_xoshiro 0.7.0",
  "regex",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "thiserror",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c58e1d47dd08af461f6aa13ec128013bb1a26183ea4dd42f323939bcbf72d4"
+checksum = "a7c287782953c94452c2f7431feff137e4fe8b8d1eb5aa9112eab83a6f11c8f2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2490,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15462425359e87540d92e277cf1174a85a174ca433bd63d27286f65ab318f2d4"
+checksum = "6bb2c94e36f57684d7fa0cd382adeedc1728d502dbbe69ad1c12f4a931f45511"
 dependencies = [
  "bincode",
  "miden-air",
@@ -2508,8 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-node?rev=c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8#c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd619f60846ce890309d65f9a5c1d8f6fcbe800c9a61f4c822d25145827ae6b3"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -2539,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "miden-standards"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612af5b544a25e318d89dca9ac958d436f9a8b209be4dda6ee2df0c21c58548e"
+checksum = "27f63cd9264dc1f9f124fe644ee631828cc9bfd71022a75cd5bc1678f3ba7b56"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -2557,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982fb99a73d12abc6088562be1f606f24cbb2673e832ba872bf86d6add566638"
+checksum = "2761dd1f8baa744c91d1ff143d954c623d5fb1d2dfec8c8ab1dac2254343d7cd"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2600,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e32f06ec896176724bbb29de6c655f856e5444319cd3824c921511cde24f87"
+checksum = "e894e952e2819545e9351f7427779f82538e51553dfaca3294301ff308086497"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -2614,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6bd365128454fe630a5441d1cf99297b6e1bba56923f00b97c1df485c37b90"
+checksum = "b1e7aac0d511aa412138ea7dfa4a6d8c76340c6028fa91313727b7ad3614711b"
 dependencies = [
  "miden-protocol",
  "miden-tx",
@@ -2624,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "477db426fc31f666d7e65b0cc907fe431d36d88d611a0594cf266104eb168b4c"
+checksum = "3846c8674ccec0c37005f99c1a599a24790ba2a5e5f4e1c7aec5f456821df835"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2635,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785c1ec4ad9994100b117b8eab8c453dcc35d3d168e4f72ac818efb700abe7b1"
+checksum = "397f5d1e8679cf17cf7713ffd9654840791a6ed5818b025bbc2fbfdce846579a"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2648,19 +2708,20 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46cec00c8cf32ec46df7542fb9ea15fbe7a5149920ef97776a4f4bc3a563e8de"
+checksum = "c8834e76299686bcce3de1685158aa4cff49b7fa5e0e00a6cc811e8f2cf5775f"
 dependencies = [
  "miden-crypto",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529c1c173506f30d3949f7a54b65f1eb318098e37ed5730a1bb9027eee2fa4b"
+checksum = "6a9e9747e9664c1a0997bb040ae291306ea0a1c74a572141ec66cec855c1b0e8"
 dependencies = [
  "lock_api",
  "loom",
@@ -2670,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997c842047ffa2d011eb65bf638a3135b2d52bce5b20770fcc6040f1b48c624a"
+checksum = "c4580df640d889c9f3c349cd2268968e44a99a8cf0df6c36ae5b1fb273712b00"
 dependencies = [
  "bincode",
  "miden-air",
@@ -2860,7 +2921,7 @@ dependencies = [
  "paste",
  "rustc-demangle",
  "rustc-hash",
- "semver 1.0.27",
+ "semver 1.0.28",
  "smallvec",
 ]
 
@@ -3669,12 +3730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,7 +3751,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3755,6 +3810,17 @@ checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
 dependencies = [
  "fixed-hash",
  "uint",
+]
+
+[[package]]
+name = "priority-queue"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+dependencies = [
+ "equivalent",
+ "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -3904,6 +3970,20 @@ dependencies = [
  "miette",
  "prost-types",
  "thiserror",
+]
+
+[[package]]
+name = "pubgrub"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5df7e552bc7edd075f5783a87fbfc21d6a546e32c16985679c488c18192d83"
+dependencies = [
+ "indexmap",
+ "log",
+ "priority-queue",
+ "rustc-hash",
+ "thiserror",
+ "version-ranges",
 ]
 
 [[package]]
@@ -4205,7 +4285,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -4367,9 +4447,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -4389,6 +4469,18 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
 ]
 
 [[package]]
@@ -4446,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4460,7 +4552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4827,9 +4919,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes",
  "libc",
@@ -4842,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4907,7 +4999,7 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -4916,14 +5008,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.1",
@@ -4949,9 +5041,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -4978,7 +5070,7 @@ checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.0",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -4987,9 +5079,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -5002,9 +5094,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -5234,7 +5326,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.0+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -5252,6 +5344,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -5360,6 +5458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version-ranges"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3595ffe225639f1e0fd8d7269dcc05d2fbfea93cfac2fea367daf1adb60aae91"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5419,9 +5526,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5432,9 +5539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5442,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5452,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5465,9 +5572,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5484,12 +5591,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.245.1",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -5525,7 +5632,7 @@ checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
 dependencies = [
  "bitflags",
  "indexmap",
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5537,18 +5644,18 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.245.1"
+version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags",
  "indexmap",
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5564,31 +5671,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "246.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5839,7 +5946,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,8 +473,7 @@ dependencies = [
 [[package]]
 name = "cargo-miden"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16dd37db0856097b45d02483f9f7969d6a7d7a74f4316e0e4aab21ee2cc32389"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1658,6 +1657,7 @@ dependencies = [
  "miden-client",
  "miden-client-sqlite-store",
  "miden-mast-package",
+ "miden-standards",
  "miden-testing",
  "rand 0.9.2",
  "tokio",
@@ -2747,8 +2747,7 @@ dependencies = [
 [[package]]
 name = "midenc-codegen-masm"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f6077b02b2a13cd32e5d8d2f9544956ff97ce620eb8a5f5bc97c45dcf415f5"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "anyhow",
  "inventory",
@@ -2777,8 +2776,7 @@ dependencies = [
 [[package]]
 name = "midenc-compile"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de61df7d6ac8e056ef19896ff967dd859d40a416f91f4f60ea7c1a0c9061664"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "anyhow",
  "clap",
@@ -2800,8 +2798,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-arith"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa4be06a8cd187e7d9b25ab4b3c6dad83cb991383e26da00275c70d529548b6"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "midenc-hir",
  "paste",
@@ -2810,8 +2807,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-cf"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e229db2ad095f1f34d3a142718dc7f1ac866016e13c6efcd0bb3238d866c23"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2821,8 +2817,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-hir"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b379e766985819b45322cb96faf9847ed38aa7bd6fd5a0776dc10d577e64733a"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2835,8 +2830,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-scf"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4904a0d020c26ef4463424c300729bbb30c3f5d64dc83e00862c98c371e87670"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "bitvec",
  "log",
@@ -2850,8 +2844,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-ub"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f95175939c0f026e906186b77bf6ccc30667cfae8b08f365c2fa5bec98333c37"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "midenc-hir",
 ]
@@ -2859,8 +2852,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-wasm"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca8945bd0a7816c7703bd07319931ca02b91f07e7e7983e640e51a8a7919e4"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "midenc-dialect-arith",
  "midenc-dialect-hir",
@@ -2870,8 +2862,7 @@ dependencies = [
 [[package]]
 name = "midenc-frontend-wasm"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fae37430ad4c05666dd72413a4e09f6fae0dcfd536f85372ae349c361e6d11"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "addr2line 0.24.2",
  "anyhow",
@@ -2886,6 +2877,7 @@ dependencies = [
  "midenc-dialect-hir",
  "midenc-dialect-ub",
  "midenc-dialect-wasm",
+ "midenc-frontend-wasm-metadata",
  "midenc-hir",
  "midenc-hir-symbol",
  "midenc-session",
@@ -2894,10 +2886,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "midenc-frontend-wasm-metadata"
+version = "0.8.0"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "midenc-hir"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23578c2fe9906f459a3a1d50ea125d1093fdc43e46f5c48168b72c28ebe4743"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "anyhow",
  "base64",
@@ -2928,8 +2928,7 @@ dependencies = [
 [[package]]
 name = "midenc-hir-analysis"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41689f2b52c1dbd03bb94d3e6d498f20cb68ae21d3f38282ec5402103acc6ab"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "bitvec",
  "blink-alloc",
@@ -2940,8 +2939,7 @@ dependencies = [
 [[package]]
 name = "midenc-hir-macros"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0413089b9139dbb888bb9aef514d9bf7d0938c024968c6c21a6cae5340a15"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "Inflector",
  "darling",
@@ -2953,8 +2951,7 @@ dependencies = [
 [[package]]
 name = "midenc-hir-symbol"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b39f97813438f6cbecfd91781f90890d869f3bf7d29c8f3ca9c5263b53b8f"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "Inflector",
  "compact_str",
@@ -2969,8 +2966,7 @@ dependencies = [
 [[package]]
 name = "midenc-hir-transform"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811895c7674eb8e1d9056b4a0e6907c91546589e951d2b3318ae6113bbc7317a"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "log",
  "midenc-hir",
@@ -2995,8 +2991,7 @@ dependencies = [
 [[package]]
 name = "midenc-log"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c254024e5cc30a4b2ac95e3d4b628a715e2de0e6d7b3fb056d9ac7e115ce301"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -3008,8 +3003,7 @@ dependencies = [
 [[package]]
 name = "midenc-session"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1c66774ceb89d0dbbd79410c2084cb877b09d0bb62a33548a645e9b7e1886a"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
 
 [[package]]
+name = "alloy-primitives"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "itoa",
+ "paste",
+ "ruint",
+ "rustc-hash",
+ "sha3",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "syn 2.0.117",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,7 +165,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -100,15 +190,24 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -135,12 +234,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "anymap2"
@@ -177,7 +273,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -247,6 +343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,9 +368,18 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "bitvec"
@@ -312,10 +426,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "bstr"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "build-rs"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc87f52297187fb5d25bde3d368f0480f88ac1d8f3cf4c80ac5575435511114"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -341,8 +473,7 @@ dependencies = [
 [[package]]
 name = "cargo-miden"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca0c98579395e4b8d426291a15a13effa759c20db975550c6e3f9f7fa2de2d9"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -395,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -437,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -461,9 +592,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -471,38 +602,40 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -519,6 +652,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,6 +674,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -614,6 +768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,14 +820,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -675,27 +835,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -740,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -762,10 +921,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -782,9 +943,15 @@ dependencies = [
 
 [[package]]
 name = "dissimilar"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
+checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
@@ -852,18 +1019,18 @@ dependencies = [
 
 [[package]]
 name = "ena"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -871,11 +1038,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "env_filter",
  "jiff",
@@ -939,6 +1106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,7 +1139,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -979,16 +1155,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
 name = "fs-err"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
 dependencies = [
  "autocfg",
 ]
@@ -1001,9 +1171,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1016,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1026,15 +1196,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1043,38 +1213,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1084,7 +1254,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1148,10 +1317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1175,6 +1346,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -1214,7 +1397,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2 0.2.21",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash",
 ]
 
 [[package]]
@@ -1222,14 +1405,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2 0.2.21",
- "equivalent",
- "foldhash 0.2.0",
- "rayon",
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "hashlink"
@@ -1414,6 +1589,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "im-rc"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.6.4",
+ "rand_xoshiro 0.6.0",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,7 +1639,7 @@ dependencies = [
  "miden-client-sqlite-store",
  "miden-mast-package",
  "miden-testing",
- "rand",
+ "rand 0.9.2",
  "tokio",
 ]
 
@@ -1465,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
+checksum = "8062b737e5389949f477d4760a2ebbff0c366f97798f2419b8d8f366363d3342"
 dependencies = [
  "rustversion",
 ]
@@ -1495,15 +1684,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1514,13 +1703,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1535,10 +1724,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1559,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -1603,6 +1794,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
+ "regex-automata",
  "rustversion",
 ]
 
@@ -1620,9 +1812,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libm"
@@ -1643,15 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "liquid"
@@ -1690,7 +1876,7 @@ checksum = "de66c928222984aea59fcaed8ba627f388aaac3c1f57dcb05cc25495ef8faefe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1705,6 +1891,58 @@ dependencies = [
  "regex",
  "time",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "litcheck-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00d04c87eac46e722dea009607dbf01109872ccabdaa9088399f2a21c6b2a71d"
+dependencies = [
+ "Inflector",
+ "clap",
+ "compact_str",
+ "either",
+ "glob",
+ "hashbrown 0.15.5",
+ "log",
+ "memchr",
+ "miette",
+ "parking_lot",
+ "paste",
+ "rustc-hash",
+ "serde",
+ "serde_spanned 1.1.0",
+ "smallvec",
+ "thiserror",
+ "toml 0.9.12+spec-1.1.0",
+ "walkdir",
+]
+
+[[package]]
+name = "litcheck-filecheck"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3068bd232903a957c3dd219019857542dcc8e57eee9db2cebd08c916d8d989c"
+dependencies = [
+ "aho-corasick",
+ "bitflags",
+ "bstr",
+ "clap",
+ "either",
+ "im-rc",
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "litcheck-core",
+ "log",
+ "logos 0.16.1",
+ "memchr",
+ "regex",
+ "regex-automata",
+ "regex-syntax",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -1728,7 +1966,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
 dependencies = [
- "logos-derive",
+ "logos-derive 0.15.1",
+]
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive 0.16.1",
 ]
 
 [[package]]
@@ -1744,7 +1991,21 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version 0.4.1",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1753,7 +2014,16 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
 dependencies = [
- "logos-codegen",
+ "logos-codegen 0.15.1",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen 0.16.1",
 ]
 
 [[package]]
@@ -1770,6 +2040,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,15 +2061,15 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
 ]
@@ -1804,39 +2085,43 @@ dependencies = [
 
 [[package]]
 name = "miden-agglayer"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a867217bab689c0539f6b4797cb452f0932de6904479a38f1322e045b9383b"
+checksum = "98863d46f0f288b03f52a4591230b6ddded2b2110b4e0f9268d4b6f19efe49ba"
 dependencies = [
+ "alloy-sol-types",
  "fs-err",
  "miden-assembly",
  "miden-core",
  "miden-core-lib",
+ "miden-crypto",
  "miden-protocol",
  "miden-standards",
  "miden-utils-sync",
+ "primitive-types",
  "regex",
+ "thiserror",
  "walkdir",
 ]
 
 [[package]]
 name = "miden-air"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33eacdeeaf50a704b221efe81abf1f1e9870154c5bd4acc11f5ad3f872e73509"
+checksum = "5322d00bef8b19f4cd3415da2533a87c8860c7d9b80043d6cce0f184b40c5fff"
 dependencies = [
  "miden-core",
+ "miden-crypto",
  "miden-utils-indexing",
  "thiserror",
- "winter-air",
- "winter-prover",
+ "tracing",
 ]
 
 [[package]]
 name = "miden-assembly"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdebc6a73964aaf92179d9a9925ca48d662894f24774ab6380e784214de00fdb"
+checksum = "7ece22da0cbf350e4a2939a07eaa3200445e42e47ce1b1ee6538723b6b40a4d4"
 dependencies = [
  "env_logger",
  "log",
@@ -1849,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7b96df3facd26ae58fe0c3c30bd1d8e83c2b7f0b0c9c046800901dc1eff14e"
+checksum = "d84a0e14ce66e76497a6771f3e360eb85557f2417ea22db279d54c1238ffafde"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -1873,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "miden-block-prover"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e92a0ddae8d0983e37bc636edba741947b1e3dc63baed2ad85921342080154a"
+checksum = "9710309c899f329e92853b1e396d01d6d0876dc5a95555b786cf7e6c93eae5bd"
 dependencies = [
  "miden-protocol",
  "thiserror",
@@ -1883,44 +2168,43 @@ dependencies = [
 
 [[package]]
 name = "miden-client"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b256399e6f0d7ae53a592b771a1286c46ca6b45397d1c5fda6d83dbd222357"
+version = "0.14.0"
+source = "git+https://github.com/0xMiden/miden-client?branch=release%2Fv0.14.0-beta#6ccf66a8d2795b9b8778b3c6f98c6e4158c576ed"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
  "futures",
  "getrandom 0.3.4",
+ "gloo-timers",
  "hex",
- "miden-mast-package",
  "miden-node-proto-build",
  "miden-note-transport-proto-build",
  "miden-protocol",
  "miden-remote-prover-client",
  "miden-standards",
- "miden-testing",
  "miden-tx",
  "miette",
  "prost",
  "prost-types",
- "rand",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
  "thiserror",
+ "tokio",
  "tonic",
  "tonic-health",
  "tonic-prost",
  "tonic-prost-build",
  "tonic-web-wasm-client",
  "tracing",
- "uuid",
  "web-sys",
 ]
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa3bc8ad4ffc4cfce3a812056251d08c8f3547fab2ede695d0ce719280d1ed5"
+version = "0.14.0"
+source = "git+https://github.com/0xMiden/miden-client?branch=release%2Fv0.14.0-beta#6ccf66a8d2795b9b8778b3c6f98c6e4158c576ed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1937,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cb3c6b071a7a5fc6a10dfbaed76f3d0170f3739a231233a3c5e27596a5612f"
+checksum = "7bf4f5601b0d669aa125cce3bba4b98f2c8df729e2d53e66777429ac5f53e228"
 dependencies = [
  "derive_more",
  "itertools",
@@ -1948,20 +2232,19 @@ dependencies = [
  "miden-formatting",
  "miden-utils-core-derive",
  "miden-utils-indexing",
+ "miden-utils-sync",
  "num-derive",
  "num-traits",
  "proptest",
  "proptest-derive",
  "thiserror",
- "winter-math",
- "winter-utils",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703c0e94089a3135ba75e3586fcb4e5d61e3bee10a7ee1dad0b2ac0a497c14e9"
+checksum = "82595fabb062315c32f6fc11c31755d3e5c6f8bc8c67d35154a067397d65b1de"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -1970,15 +2253,14 @@ dependencies = [
  "miden-crypto",
  "miden-processor",
  "miden-utils-sync",
- "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.19.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e28b6e110f339c2edc2760a8cb94863f0a055ee658a49bc90c8560eff2feef4"
+checksum = "0ed0a034a460e27723dcfdf25effffab84331c3b46b13e7a1bd674197cc71bfe"
 dependencies = [
  "blake3",
  "cc",
@@ -1987,42 +2269,51 @@ dependencies = [
  "ed25519-dalek",
  "flume",
  "glob",
- "hashbrown 0.16.1",
  "hkdf",
  "k256",
  "miden-crypto-derive",
+ "miden-field",
+ "miden-serde-utils",
  "num",
  "num-complex",
- "rand",
+ "p3-blake3",
+ "p3-challenger",
+ "p3-dft",
+ "p3-goldilocks",
+ "p3-keccak",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lifted-stark",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_core 0.9.5",
  "rand_hc",
  "rayon",
+ "serde",
  "sha2",
  "sha3",
  "subtle",
  "thiserror",
- "winter-crypto",
- "winter-math",
- "winter-utils",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.19.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40e95b9c7c99ed6bbf073d9e02721d812dedd2c195019c0a0e0a3dbb9cbf034"
+checksum = "e8bf6ebde028e79bcc61a3632d2f375a5cc64caa17d014459f75015238cb1e08"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "miden-debug-types"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb127273a9ee9ac1f9ad71899c1c2a0dea8cf768a90024d2d8b91800980c756"
+checksum = "c9ef08bafef275f0d6a15108108b3f6df6642772e0a1c05e102cb7e96841e888"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2032,7 +2323,25 @@ dependencies = [
  "miden-utils-sync",
  "paste",
  "serde",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.0",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-field"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
+dependencies = [
+ "miden-serde-utils",
+ "num-bigint",
+ "p3-challenger",
+ "p3-field",
+ "p3-goldilocks",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "subtle",
  "thiserror",
 ]
 
@@ -2047,13 +2356,14 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7b21cd2593ed5930d5af10b197917dd6668ab34e203e47fb9c1ba712dc9a2c"
+checksum = "f9b24d09fda64e0751f943ac616643342b05a47d626e2ee0040b902eff3c924e"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
  "miden-core",
+ "miden-debug-types",
  "thiserror",
 ]
 
@@ -2063,8 +2373,6 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef536978f24a179d94fa2a41e4f92b28e7d8aab14b8d23df28ad2a3d7098b20"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "futures",
  "indenter",
@@ -2075,13 +2383,9 @@ dependencies = [
  "rustc_version 0.2.3",
  "rustversion",
  "serde_json",
- "spin",
+ "spin 0.9.8",
  "strip-ansi-escapes",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "syn 2.0.114",
- "terminal_size 0.3.0",
+ "syn 2.0.117",
  "textwrap",
  "thiserror",
  "trybuild",
@@ -2096,15 +2400,15 @@ checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "miden-node-proto-build"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba5dcc0fa93d0d647cd4f39327f01d55adc843c0b1be3b122794cb5ffdb85c2"
+version = "0.14.0"
+source = "git+https://github.com/0xMiden/miden-node?rev=a329b4c7fc5592bd2844242f8a325084e76c9512#a329b4c7fc5592bd2844242f8a325084e76c9512"
 dependencies = [
+ "build-rs",
  "fs-err",
  "miette",
  "protox",
@@ -2125,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72712c2c71774f7a49d66a0265b57be7a283919ffbdc4b034ab355b0283de021"
+checksum = "ba53ff06ef0affa0c3fb13e7e2ef5bde99f96eebcec8c360c6658050480ef676"
 dependencies = [
  "itertools",
  "miden-air",
@@ -2140,14 +2444,13 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "winter-prover",
 ]
 
 [[package]]
 name = "miden-protocol"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785be319a826c9cb43d2e1a41a1fb1eee3f2baafe360e0d743690641f7c93ad5"
+checksum = "38c30a20ea30071544a827d0daa12e343e444c1e314d1a4560c43f2d6c7b43c6"
 dependencies = [
  "bech32",
  "fs-err",
@@ -2162,51 +2465,54 @@ dependencies = [
  "miden-protocol-macros",
  "miden-utils-sync",
  "miden-verifier",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
- "rand_xoshiro",
+ "rand_xoshiro 0.7.0",
  "regex",
  "semver 1.0.27",
  "serde",
  "thiserror",
- "toml 0.9.11+spec-1.1.0",
+ "toml 1.1.0+spec-1.1.0",
  "walkdir",
- "winter-rand-utils",
 ]
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dc854c1b9e49e82d3f39c5710345226e0b2a62ec0ea220c616f1f3a099cfb3"
+checksum = "76c58e1d47dd08af461f6aa13ec128013bb1a26183ea4dd42f323939bcbf72d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "miden-prover"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6a65651c8bf931743580c4a8c00a35f3453da39679bd23fa95f29ae7849ffd"
+checksum = "15462425359e87540d92e277cf1174a85a174ca433bd63d27286f65ab318f2d4"
 dependencies = [
+ "bincode",
  "miden-air",
+ "miden-core",
+ "miden-crypto",
  "miden-debug-types",
  "miden-processor",
+ "serde",
+ "thiserror",
+ "tokio",
  "tracing",
- "winter-maybe-async",
- "winter-prover",
 ]
 
 [[package]]
 name = "miden-remote-prover-client"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1badab21e9a4680c3cf2b04857d0141fd499fc1da615eaa785ae7d191aa43f6"
+version = "0.14.0"
+source = "git+https://github.com/0xMiden/miden-node?rev=a329b4c7fc5592bd2844242f8a325084e76c9512#a329b4c7fc5592bd2844242f8a325084e76c9512"
 dependencies = [
+ "build-rs",
  "fs-err",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "miden-node-proto-build",
  "miden-protocol",
  "miden-tx",
@@ -2221,10 +2527,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "miden-standards"
-version = "0.13.3"
+name = "miden-serde-utils"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e33771fc35e1e640582bcd26c88b2ab449dd3a70888b315546d0d3447f4bb3"
+checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
+dependencies = [
+ "p3-field",
+ "p3-goldilocks",
+]
+
+[[package]]
+name = "miden-standards"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612af5b544a25e318d89dca9ac958d436f9a8b209be4dda6ee2df0c21c58548e"
 dependencies = [
  "fs-err",
  "miden-assembly",
@@ -2232,7 +2548,7 @@ dependencies = [
  "miden-core-lib",
  "miden-processor",
  "miden-protocol",
- "rand",
+ "rand 0.9.2",
  "regex",
  "thiserror",
  "walkdir",
@@ -2240,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "miden-testing"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae5d41a888d1a5e520a9312a170975d0fbadefb1b9200543cebdf54dd0960310"
+checksum = "982fb99a73d12abc6088562be1f606f24cbb2673e832ba872bf86d6add566638"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2250,14 +2566,15 @@ dependencies = [
  "miden-assembly",
  "miden-block-prover",
  "miden-core-lib",
+ "miden-crypto",
  "miden-processor",
  "miden-protocol",
  "miden-standards",
  "miden-tx",
  "miden-tx-batch-prover",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
- "winterfell",
+ "thiserror",
 ]
 
 [[package]]
@@ -2277,14 +2594,14 @@ checksum = "0ee4176a0f2e7d29d2a8ee7e60b6deb14ce67a20e94c3e2c7275cdb8804e1862"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "miden-tx"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430e4ee02b5efb71b104926e229441e0071a93a259a70740bf8c436495caa64f"
+checksum = "18e32f06ec896176724bbb29de6c655f856e5444319cd3824c921511cde24f87"
 dependencies = [
  "miden-processor",
  "miden-protocol",
@@ -2296,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "miden-tx-batch-prover"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03bc209b6487ebac0de230461e229a99d17ed73596c7d99fc59eea47a28a89cc"
+checksum = "eb6bd365128454fe630a5441d1cf99297b6e1bba56923f00b97c1df485c37b90"
 dependencies = [
  "miden-protocol",
  "miden-tx",
@@ -2306,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3753ff5c16cb83244d234b7f76fb8abec3377200b215859fe599c41465e7d36b"
+checksum = "477db426fc31f666d7e65b0cc907fe431d36d88d611a0594cf266104eb168b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2317,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6c667538374e6a3579397a29f82d94e62d2f9cf1eca8a95da1a7acbfed381d"
+checksum = "785c1ec4ad9994100b117b8eab8c453dcc35d3d168e4f72ac818efb700abe7b1"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -2330,42 +2647,45 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e135423d4d3d626ea15fdfe7070abe5f7908ac71a2d174c832c870668fb2a3"
+checksum = "46cec00c8cf32ec46df7542fb9ea15fbe7a5149920ef97776a4f4bc3a563e8de"
 dependencies = [
+ "miden-crypto",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e678634bd9ce5d6f89809cda926a268bcbfe72aa0a5d2031a0c8182074992"
+checksum = "9529c1c173506f30d3949f7a54b65f1eb318098e37ed5730a1bb9027eee2fa4b"
 dependencies = [
  "lock_api",
  "loom",
+ "once_cell",
  "parking_lot",
 ]
 
 [[package]]
 name = "miden-verifier"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9513494a2a8cd876150bbbb5a2985b078368de280cc8a52e9aff41320c344b7"
+checksum = "997c842047ffa2d011eb65bf638a3135b2d52bce5b20770fcc6040f1b48c624a"
 dependencies = [
+ "bincode",
  "miden-air",
  "miden-core",
+ "miden-crypto",
+ "serde",
  "thiserror",
  "tracing",
- "winter-verifier",
 ]
 
 [[package]]
 name = "midenc-codegen-masm"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c54879392f789655df7e7f20529d8b6cf74c9dbdfc7fd9503652ff17aaf2b2b"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "anyhow",
  "inventory",
@@ -2382,6 +2702,7 @@ dependencies = [
  "midenc-dialect-hir",
  "midenc-dialect-scf",
  "midenc-dialect-ub",
+ "midenc-dialect-wasm",
  "midenc-hir",
  "midenc-hir-analysis",
  "midenc-session",
@@ -2393,8 +2714,7 @@ dependencies = [
 [[package]]
 name = "midenc-compile"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f298a25b16cb27d7ec3556a92e4c5cfcf50a10f74d96f3bbef4513d7a3f5823a"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "anyhow",
  "clap",
@@ -2416,8 +2736,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-arith"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c9399a7668ae72f74c2af75451d62cb0ace01811f31e69c13b9c79413e0278"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "midenc-hir",
  "paste",
@@ -2426,8 +2745,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-cf"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20b5838ffde704bbba43be5388a1de965bf1507bd5423123fc58d7f5743ea6d3"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2437,8 +2755,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-hir"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107eb44e0ad8305f7b548376c9a162e8413310dda7774879888f74555ab17e53"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2451,8 +2768,7 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-scf"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f881ad5ee0cf902813d232ea33bb9f60f50d0842207bda3f4e6fb8015176daaa"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "bitvec",
  "log",
@@ -2466,17 +2782,25 @@ dependencies = [
 [[package]]
 name = "midenc-dialect-ub"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21417d509e2d4c848052bd7562609ecdaf0838ad78245b711855f1eb5e509f4"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
+ "midenc-hir",
+]
+
+[[package]]
+name = "midenc-dialect-wasm"
+version = "0.7.1"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+dependencies = [
+ "midenc-dialect-arith",
+ "midenc-dialect-hir",
  "midenc-hir",
 ]
 
 [[package]]
 name = "midenc-frontend-wasm"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77635a95819379e5682f67f56602a499b1f8524efab056c3ab9d5a43adec3875"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "addr2line 0.24.2",
  "anyhow",
@@ -2490,6 +2814,7 @@ dependencies = [
  "midenc-dialect-cf",
  "midenc-dialect-hir",
  "midenc-dialect-ub",
+ "midenc-dialect-wasm",
  "midenc-hir",
  "midenc-hir-symbol",
  "midenc-session",
@@ -2500,10 +2825,10 @@ dependencies = [
 [[package]]
 name = "midenc-hir"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64562538a7b7ac4debac9ab47fb0b98b254dfb9771cdf1744b143ae5f7eebaba"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "anyhow",
+ "base64",
  "bitflags",
  "bitvec",
  "blink-alloc",
@@ -2511,13 +2836,17 @@ dependencies = [
  "hashbrown 0.15.5",
  "intrusive-collections",
  "inventory",
+ "litcheck-core",
+ "litcheck-filecheck",
  "log",
+ "memchr",
  "miden-core",
  "miden-thiserror",
  "midenc-hir-macros",
  "midenc-hir-symbol",
  "midenc-hir-type",
  "midenc-session",
+ "paste",
  "rustc-demangle",
  "rustc-hash",
  "semver 1.0.27",
@@ -2527,8 +2856,7 @@ dependencies = [
 [[package]]
 name = "midenc-hir-analysis"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71bdc7699e403e6824153df8cd82e53c242600986956904a9dc89c2c461c127"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "bitvec",
  "blink-alloc",
@@ -2539,23 +2867,22 @@ dependencies = [
 [[package]]
 name = "midenc-hir-macros"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d68bb1097da97ae38254937452fb4b950f3e2822fc4ebfe073b606bfba1a40e"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "Inflector",
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "midenc-hir-symbol"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b7717e82e24e8aa676ff09928cd58d41572dcbe022a7da4f3b7a1ab54a5e6"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "Inflector",
+ "compact_str",
  "hashbrown 0.15.5",
  "lock_api",
  "miden-formatting",
@@ -2567,8 +2894,7 @@ dependencies = [
 [[package]]
 name = "midenc-hir-transform"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41dbdb37d72b330160f29236448aa03bce11d592018e1e38557db1647f22d30"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "log",
  "midenc-hir",
@@ -2578,11 +2904,12 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.4.3"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4cfab04baffdda3fb9eafa5f873604059b89a1699aa95e4f1057397a69f0b5"
+checksum = "2eb29d7c049fb69373c7e775e3d4411e63e4ee608bc43826282ba62c6ec9f891"
 dependencies = [
  "miden-formatting",
+ "miden-serde-utils",
  "serde",
  "serde_repr",
  "smallvec",
@@ -2592,10 +2919,9 @@ dependencies = [
 [[package]]
 name = "midenc-log"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a078667be27aae60834a2b72fd46ec693fa8719e6787f4ec30f42bd04732ad64"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "jiff",
  "log",
@@ -2605,8 +2931,7 @@ dependencies = [
 [[package]]
 name = "midenc-session"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c1747efc3dff0a0d79bd8293a3a1a2e81c063b7217bc4780e11a184a85c2f7"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "anyhow",
  "clap",
@@ -2641,7 +2966,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.4.3",
+ "terminal_size",
  "textwrap",
  "unicode-width 0.1.14",
 ]
@@ -2654,7 +2979,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2669,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2743,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -2755,7 +3080,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2831,9 +3156,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2855,9 +3180,324 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "p3-air"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
+dependencies = [
+ "p3-field",
+ "p3-matrix",
+ "tracing",
+]
+
+[[package]]
+name = "p3-blake3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
+dependencies = [
+ "blake3",
+ "p3-symmetric",
+ "p3-util",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+dependencies = [
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-monty-31",
+ "p3-symmetric",
+ "p3-util",
+ "tracing",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
+dependencies = [
+ "itertools",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+dependencies = [
+ "itertools",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-util",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-maybe-rayon",
+ "p3-util",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+dependencies = [
+ "num-bigint",
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-mds",
+ "p3-poseidon1",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+]
+
+[[package]]
+name = "p3-keccak"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
+dependencies = [
+ "p3-symmetric",
+ "p3-util",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+dependencies = [
+ "itertools",
+ "p3-field",
+ "p3-maybe-rayon",
+ "p3-util",
+ "rand 0.10.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+dependencies = [
+ "p3-dft",
+ "p3-field",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-miden-lifted-air"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
+dependencies = [
+ "p3-air",
+ "p3-field",
+ "p3-matrix",
+ "p3-util",
+ "thiserror",
+]
+
+[[package]]
+name = "p3-miden-lifted-fri"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
+dependencies = [
+ "p3-challenger",
+ "p3-commit",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lmcs",
+ "p3-miden-transcript",
+ "p3-util",
+ "rand 0.10.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lifted-stark"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
+dependencies = [
+ "p3-challenger",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-lifted-air",
+ "p3-miden-lifted-fri",
+ "p3-miden-lmcs",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-util",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lmcs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
+dependencies = [
+ "p3-commit",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.0",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-stateful-hasher"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
+dependencies = [
+ "p3-field",
+ "p3-symmetric",
+]
+
+[[package]]
+name = "p3-miden-transcript"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
+dependencies = [
+ "p3-challenger",
+ "p3-field",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-dft",
+ "p3-field",
+ "p3-matrix",
+ "p3-maybe-rayon",
+ "p3-mds",
+ "p3-poseidon1",
+ "p3-poseidon2",
+ "p3-symmetric",
+ "p3-util",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-poseidon1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+dependencies = [
+ "p3-field",
+ "p3-symmetric",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+dependencies = [
+ "p3-field",
+ "p3-mds",
+ "p3-symmetric",
+ "p3-util",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+dependencies = [
+ "itertools",
+ "p3-field",
+ "p3-util",
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+dependencies = [
+ "rayon",
+ "serde",
+ "transpose",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2914,9 +3554,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2924,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f9dbced329c441fa79d80472764b1a2c7e57123553b8519b36663a2fb234ed"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2934,22 +3574,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb96d5051a78f44f43c8f712d8e810adb0ebf923fc9ed2655a7f66f63ba8ee5"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.5"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -2987,29 +3627,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3052,9 +3692,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -3087,7 +3727,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
+dependencies = [
+ "fixed-hash",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3101,13 +3773,13 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3122,14 +3794,14 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3137,23 +3809,22 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
  "itertools",
  "log",
  "multimap",
- "once_cell",
- "petgraph 0.7.1",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -3167,7 +3838,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3176,7 +3847,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
 dependencies = [
- "logos",
+ "logos 0.15.1",
  "miette",
  "prost",
  "prost-types",
@@ -3184,18 +3855,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "protox"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8555716f64c546306ddf3383065dc40d4232609e79e0a4c50e94e87d54f30fb4"
+checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
 dependencies = [
  "bytes",
  "miette",
@@ -3212,7 +3883,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
 dependencies = [
- "logos",
+ "logos 0.15.1",
  "miette",
  "prost-types",
  "thiserror",
@@ -3220,9 +3891,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
  "bitflags",
  "memchr",
@@ -3231,18 +3902,18 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "21.1.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8246feae3db61428fd0bb94285c690b460e4517d83152377543ca802357785f1"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3267,12 +3938,30 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3304,6 +3993,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
 name = "rand_hc"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3319,6 +4014,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3384,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
@@ -3411,6 +4115,27 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+dependencies = [
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.2",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rusqlite"
@@ -3444,9 +4169,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3468,35 +4193,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -3530,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3556,9 +4268,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3571,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -3606,9 +4318,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3619,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3679,7 +4391,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3703,7 +4415,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3717,9 +4429,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3772,15 +4484,25 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"
@@ -3805,12 +4527,12 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3818,6 +4540,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]
@@ -3843,6 +4574,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -3911,13 +4648,25 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3940,14 +4689,14 @@ checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -3971,22 +4720,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
-dependencies = [
- "rustix 1.1.3",
- "windows-sys 0.60.2",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4017,7 +4756,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4031,9 +4770,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -4052,19 +4791,28 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.49.0"
+name = "tiny-keccak"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -4077,13 +4825,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4136,17 +4884,32 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.0",
+ "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4168,6 +4931,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4178,7 +4950,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4189,20 +4961,20 @@ checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -4213,15 +4985,15 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
 name = "tonic"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -4249,21 +5021,21 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
+checksum = "1882ac3bf5ef12877d7ed57aad87e75154c11931c2ba7e6cde5e22d63522c734"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tonic-health"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dbde2c702c4be12b9b2f6f7e6c824a84a7b7be177070cada8ee575a581af359"
+checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
 dependencies = [
  "prost",
  "tokio",
@@ -4274,9 +5046,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
@@ -4285,25 +5057,25 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
+checksum = "f3144df636917574672e93d0f56d7edec49f90305749c668df5101751bb8f95a"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
  "tonic-build",
 ]
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898cd44be5e23e59d2956056538f1d6b3c5336629d384ffd2d92e76f87fb98ff"
+checksum = "e8e21e20b94f808d6f2244a5d960d02c28dd82066abddd2f27019bac0535f310"
 dependencies = [
  "base64",
  "byteorder",
@@ -4374,7 +5146,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4400,9 +5172,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4417,6 +5189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4424,9 +5206,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
 dependencies = [
  "dissimilar",
  "glob",
@@ -4435,7 +5217,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.11+spec-1.1.0",
+ "toml 1.1.0+spec-1.1.0",
 ]
 
 [[package]]
@@ -4467,6 +5249,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4480,9 +5274,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4492,9 +5286,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -4535,18 +5329,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
-dependencies = [
- "getrandom 0.4.2",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "valuable"
@@ -4620,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4633,23 +5415,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4657,22 +5435,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
 dependencies = [
  "unicode-ident",
 ]
@@ -4688,6 +5466,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,15 +5483,15 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4736,6 +5524,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
+dependencies = [
+ "bitflags",
+ "indexmap",
+ "semver 1.0.27",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4748,31 +5547,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "244.0.0"
+version = "245.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e7b9f9e23311275920e3d6b56d64137c160cf8af4f84a7283b36cfecbf4acb"
+checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder",
+ "wasm-encoder 0.245.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.244.0"
+version = "1.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf35b87ed352f9ab6cd0732abde5a67dd6153dfd02c493e61459218b19456fa"
+checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
 dependencies = [
  "wast",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4808,7 +5607,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4819,7 +5618,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4848,38 +5647,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4893,57 +5665,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4952,34 +5686,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4988,28 +5698,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5018,34 +5710,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5054,150 +5722,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winter-air"
-version = "0.13.1"
+name = "winnow"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
-dependencies = [
- "libm",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-crypto"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb247bc142438798edb04067ab72a22cf815f57abbd7b78a6fa986fc101db8"
-dependencies = [
- "blake3",
- "sha3",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-fri"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
-dependencies = [
- "winter-crypto",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-math"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aecfb48ee6a8b4746392c8ff31e33e62df8528a3b5628c5af27b92b14aef1ea"
-dependencies = [
- "winter-utils",
-]
-
-[[package]]
-name = "winter-maybe-async"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
-dependencies = [
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "winter-prover"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
-dependencies = [
- "tracing",
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-maybe-async",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-rand-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ff3b651754a7bd216f959764d0a5ab6f4b551c9a3a08fb9ccecbed594b614a"
-dependencies = [
- "rand",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
-dependencies = [
- "rayon",
-]
-
-[[package]]
-name = "winter-verifier"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
-dependencies = [
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winterfell"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f824ddd5aec8ca6a54307f20c115485a8a919ea94dd26d496d856ca6185f4f"
-dependencies = [
- "winter-air",
- "winter-prover",
- "winter-verifier",
-]
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -5229,7 +5772,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5245,7 +5788,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5263,7 +5806,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
  "wasmparser 0.244.0",
  "wit-parser",
@@ -5308,22 +5851,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5334,6 +5877,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,8 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-miden"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30f09004aa4b92f7a56924a76aae792f4adcae3adcac46ac384e73cea3827694"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2746,8 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-codegen-masm"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ddea2c6050fea142e4f8c526c55bf3656c69c80e66bd099dd79728bdccda12f"
 dependencies = [
  "anyhow",
  "inventory",
@@ -2775,8 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-compile"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927ad8e3f4f47949ae63cad358bcf510634765726e57f677c4d1cddadd8233ee"
 dependencies = [
  "anyhow",
  "clap",
@@ -2797,8 +2800,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-arith"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "015e5132f919666624203c2a7d355a757a1265c419d385acc7ff8478b2a3edfe"
 dependencies = [
  "midenc-hir",
  "paste",
@@ -2806,8 +2810,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-cf"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd32b0180d00707f0d2d6050c4cd24f0fa2ef3093a643dbdbf31792ded9cdef"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2816,8 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-hir"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb7333ca7996df3809cdbabc66b840e80bff44924570823adf218a1af4364ad0"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2829,8 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-scf"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32798b83efc34a7301f6fdf77c622ef5217d4dbed1fe68c62e2c7d07686964d0"
 dependencies = [
  "bitvec",
  "log",
@@ -2843,16 +2850,18 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-ub"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b3327a327fc4a13a08a2d9791b0cba5ef21e0c4ce2a4e18433d363c8c8dc47"
 dependencies = [
  "midenc-hir",
 ]
 
 [[package]]
 name = "midenc-dialect-wasm"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3284470339b901630d30c87c7d5fff962f41dc863c8979867664040ea07552"
 dependencies = [
  "midenc-dialect-arith",
  "midenc-dialect-hir",
@@ -2861,8 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee10db6ca611ca6e829a8625e179135dc729118974ec65006f8d17120a713a1"
 dependencies = [
  "addr2line 0.24.2",
  "anyhow",
@@ -2887,8 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6938fd4efb4a2c8937c77055a3779ddda33572728328cf4391d2f240f78be3a"
 dependencies = [
  "serde",
  "serde_json",
@@ -2896,8 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51141b60afe741ff47d8d95d8b7f9a8eeb32154257181aa73ef59b7f8cbaf759"
 dependencies = [
  "anyhow",
  "base64",
@@ -2927,8 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-analysis"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc8c3b28addc2560dc4b7cf4b4297ce5119bfaf645542f96e0d9f93bcee20f0"
 dependencies = [
  "bitvec",
  "blink-alloc",
@@ -2938,8 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4df411507d77af2b7ea70fd8e8a7e67272bbcb4a248386a647673cb9e19d97"
 dependencies = [
  "Inflector",
  "darling",
@@ -2950,8 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-symbol"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e212c781c59429229ba6a33d75151257175d88f722a60c333a855a790ca61b"
 dependencies = [
  "Inflector",
  "compact_str",
@@ -2965,8 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-transform"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e1483fa0bb318eaf9b112b99280afecf917bf277a026774bf5db7db9c8964d3"
 dependencies = [
  "log",
  "midenc-hir",
@@ -2990,8 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-log"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7463ae49be6e3612436bbe6af937112a23fb27d9c4e4cfb5b49c281b3b9f1b63"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -3002,8 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-session"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6895a782776dbba38034f6db4869da700e6b685a147869135c0b0ba86d38bdf"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,8 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-miden"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16dd37db0856097b45d02483f9f7969d6a7d7a74f4316e0e4aab21ee2cc32389"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2169,7 +2170,7 @@ dependencies = [
 [[package]]
 name = "miden-client"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-client?branch=release%2Fv0.14.0-beta#6ccf66a8d2795b9b8778b3c6f98c6e4158c576ed"
+source = "git+https://github.com/0xMiden/miden-client#5af8086eb03881fcd9ac6b853f34aea660cf8560"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2204,7 +2205,7 @@ dependencies = [
 [[package]]
 name = "miden-client-sqlite-store"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-client?branch=release%2Fv0.14.0-beta#6ccf66a8d2795b9b8778b3c6f98c6e4158c576ed"
+source = "git+https://github.com/0xMiden/miden-client#5af8086eb03881fcd9ac6b853f34aea660cf8560"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2406,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "miden-node-proto-build"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-node?rev=a329b4c7fc5592bd2844242f8a325084e76c9512#a329b4c7fc5592bd2844242f8a325084e76c9512"
+source = "git+https://github.com/0xMiden/miden-node?rev=c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8#c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -2508,7 +2509,7 @@ dependencies = [
 [[package]]
 name = "miden-remote-prover-client"
 version = "0.14.0"
-source = "git+https://github.com/0xMiden/miden-node?rev=a329b4c7fc5592bd2844242f8a325084e76c9512#a329b4c7fc5592bd2844242f8a325084e76c9512"
+source = "git+https://github.com/0xMiden/miden-node?rev=c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8#c2d61c0eee9f81dd6335ed51c3424a9bd5e34dd8"
 dependencies = [
  "build-rs",
  "fs-err",
@@ -2684,8 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-codegen-masm"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f6077b02b2a13cd32e5d8d2f9544956ff97ce620eb8a5f5bc97c45dcf415f5"
 dependencies = [
  "anyhow",
  "inventory",
@@ -2713,8 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-compile"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de61df7d6ac8e056ef19896ff967dd859d40a416f91f4f60ea7c1a0c9061664"
 dependencies = [
  "anyhow",
  "clap",
@@ -2735,8 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-arith"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa4be06a8cd187e7d9b25ab4b3c6dad83cb991383e26da00275c70d529548b6"
 dependencies = [
  "midenc-hir",
  "paste",
@@ -2744,8 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-cf"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e229db2ad095f1f34d3a142718dc7f1ac866016e13c6efcd0bb3238d866c23"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2754,8 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-hir"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b379e766985819b45322cb96faf9847ed38aa7bd6fd5a0776dc10d577e64733a"
 dependencies = [
  "log",
  "midenc-dialect-arith",
@@ -2767,8 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-scf"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4904a0d020c26ef4463424c300729bbb30c3f5d64dc83e00862c98c371e87670"
 dependencies = [
  "bitvec",
  "log",
@@ -2781,16 +2788,18 @@ dependencies = [
 
 [[package]]
 name = "midenc-dialect-ub"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f95175939c0f026e906186b77bf6ccc30667cfae8b08f365c2fa5bec98333c37"
 dependencies = [
  "midenc-hir",
 ]
 
 [[package]]
 name = "midenc-dialect-wasm"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca8945bd0a7816c7703bd07319931ca02b91f07e7e7983e640e51a8a7919e4"
 dependencies = [
  "midenc-dialect-arith",
  "midenc-dialect-hir",
@@ -2799,8 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fae37430ad4c05666dd72413a4e09f6fae0dcfd536f85372ae349c361e6d11"
 dependencies = [
  "addr2line 0.24.2",
  "anyhow",
@@ -2824,8 +2834,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23578c2fe9906f459a3a1d50ea125d1093fdc43e46f5c48168b72c28ebe4743"
 dependencies = [
  "anyhow",
  "base64",
@@ -2855,8 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-analysis"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41689f2b52c1dbd03bb94d3e6d498f20cb68ae21d3f38282ec5402103acc6ab"
 dependencies = [
  "bitvec",
  "blink-alloc",
@@ -2866,8 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-macros"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0413089b9139dbb888bb9aef514d9bf7d0938c024968c6c21a6cae5340a15"
 dependencies = [
  "Inflector",
  "darling",
@@ -2878,8 +2891,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-symbol"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b39f97813438f6cbecfd91781f90890d869f3bf7d29c8f3ca9c5263b53b8f"
 dependencies = [
  "Inflector",
  "compact_str",
@@ -2893,8 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-transform"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811895c7674eb8e1d9056b4a0e6907c91546589e951d2b3318ae6113bbc7317a"
 dependencies = [
  "log",
  "midenc-hir",
@@ -2918,8 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-log"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c254024e5cc30a4b2ac95e3d4b628a715e2de0e6d7b3fb056d9ac7e115ce301"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2930,8 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-session"
-version = "0.7.1"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1c66774ceb89d0dbbd79410c2084cb877b09d0bb62a33548a645e9b7e1886a"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,9 +1136,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1389,6 +1402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1427,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1427,9 +1448,7 @@ dependencies = [
  "cargo-miden",
  "miden-client",
  "miden-client-sqlite-store",
- "miden-core",
  "miden-mast-package",
- "miden-standards",
  "miden-testing",
  "rand",
  "tokio",
@@ -1613,9 +1632,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91632f3b4fb6bd1d72aa3d78f41ffecfcf2b1a6648d8c241dbe7dbfaf4875e15"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1899,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "miden-client-sqlite-store"
-version = "0.13.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5de50937147fafbc40dd25732e15b1a410ef938d8417294ea7fa3bad900f4a"
+checksum = "0aa3bc8ad4ffc4cfce3a812056251d08c8f3547fab2ede695d0ce719280d1ed5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3235,6 +3254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,9 +3414,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de23c3319433716cf134eed225fe9986bc24f63bed9be9f20c329029e672dc7"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -3403,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite_migration"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a324f81362b5cd8f2eeef82d032172fdf2ca70aeec64962ff55a56874fe5ec41"
+checksum = "3fc9767ae49274bafd3e55be9d30405a033b7a59548327d87fd4971fbb58e264"
 dependencies = [
  "log",
  "rusqlite",
@@ -4513,11 +4538,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4580,6 +4605,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -4654,6 +4688,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4684,6 +4730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
+ "hashbrown 0.15.5",
  "indexmap",
  "semver 1.0.27",
 ]
@@ -5157,6 +5204,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
+]
 
 [[package]]
 name = "wyz"

--- a/contracts/counter-account/Cargo.lock
+++ b/contracts/counter-account/Cargo.lock
@@ -945,8 +945,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miden"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76174f46c7bd1aaf25163cb6c4cf6d9bdb1993d5466ba543c1d6c343a080b767"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1009,8 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45eaf65ed9fc03898e162c9ff9649079568075543a7bcac474f3befe1ec10ad2"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1018,8 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52bebbd631f689028da59d3c1259cb1e8309e9c59cf0a9a625a98e057bebdfe"
 dependencies = [
  "heck",
  "miden-formatting",
@@ -1036,8 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c8466611116cc47e620705c32624d9a4de0dd777ef95f03219d5580e93bcaf"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1185,8 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dba0d085dfb109ebe2a9a6b1acb014f417ae8bfebb17845991ba1c215036822"
 dependencies = [
  "miden-core",
  "miden-field 0.22.6",
@@ -1195,8 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489216f38e837d9b9a1ad66524649b92ab0fcd7d90662e52952fc56e8703d305"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1319,8 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e9824b7e7297619902c6cb73d71db08434ac07a24ca5a167e8647352698c2e"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1344,8 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44231388ca9ed654bc84e71ff2daca69fb353997066bdf8ebe19b1cf80330b53"
 dependencies = [
  "miden-field 0.22.6",
 ]
@@ -1413,8 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6938fd4efb4a2c8937c77055a3779ddda33572728328cf4391d2f240f78be3a"
 dependencies = [
  "serde",
  "serde_json",

--- a/contracts/counter-account/Cargo.lock
+++ b/contracts/counter-account/Cargo.lock
@@ -946,8 +946,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "miden"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010a8120478c5bbffa3ff1f139a01bac789331fbfef5a30f5ee6fd467225d3a2"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1011,8 +1010,7 @@ dependencies = [
 [[package]]
 name = "miden-base"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cab3453f9574645a7e0ace17aa87998ebe9efde5ae2291ad9a310d6051aa0e"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1021,11 +1019,12 @@ dependencies = [
 [[package]]
 name = "miden-base-macros"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6389b82f5b125fd5c02fbf057e2d801aed3e4b3a22b73ca27601f5546343abe"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "heck",
+ "miden-formatting",
  "miden-protocol",
+ "midenc-frontend-wasm-metadata",
  "proc-macro2",
  "quote",
  "semver 1.0.27",
@@ -1038,8 +1037,7 @@ dependencies = [
 [[package]]
 name = "miden-base-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842a10d5a6f4b4710356c5cd026400eb901f380e4e445e6bfb084985963b0f88"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1188,8 +1186,7 @@ dependencies = [
 [[package]]
 name = "miden-field-repr"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c87de3a3d7535308e525fb8407defd4e7a169c6af575e148538b83800ffc6d2"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-core",
  "miden-field 0.22.6",
@@ -1199,8 +1196,7 @@ dependencies = [
 [[package]]
 name = "miden-field-repr-derive"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f1c00fe41ffa413b0ad36236e1016a64125162703f7be985d79f8dff3f7dba"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1324,8 +1320,7 @@ dependencies = [
 [[package]]
 name = "miden-sdk-alloc"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43d6123657c5ddd606ef3d36bb1bacd345abcfdbc2ca9b0cab8e839e63558f2"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1350,8 +1345,7 @@ dependencies = [
 [[package]]
 name = "miden-stdlib-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0fad7b45aa92ca52a7fb15b20cb2be0eec1472bd36a1f20cc10d649507919d"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-field 0.22.6",
 ]
@@ -1415,6 +1409,15 @@ dependencies = [
  "serde",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "midenc-frontend-wasm-metadata"
+version = "0.8.0"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/contracts/counter-account/Cargo.lock
+++ b/contracts/counter-account/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,7 +57,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -83,7 +68,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -120,30 +105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +121,15 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -322,6 +292,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -525,16 +501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,7 +537,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -704,12 +670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,12 +757,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -947,12 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,13 +946,12 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "miden"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ecb2c6a5ccd0834bfe0b7fb09e4d4bbf7f9228b3739cbb9dc5777df39e0989"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-base",
  "miden-base-macros",
  "miden-base-sys",
- "miden-field",
+ "miden-field 0.22.6",
  "miden-field-repr",
  "miden-sdk-alloc",
  "miden-stdlib-sys",
@@ -1013,22 +960,22 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33eacdeeaf50a704b221efe81abf1f1e9870154c5bd4acc11f5ad3f872e73509"
+checksum = "5322d00bef8b19f4cd3415da2533a87c8860c7d9b80043d6cce0f184b40c5fff"
 dependencies = [
  "miden-core",
+ "miden-crypto",
  "miden-utils-indexing",
  "thiserror",
- "winter-air",
- "winter-prover",
+ "tracing",
 ]
 
 [[package]]
 name = "miden-assembly"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdebc6a73964aaf92179d9a9925ca48d662894f24774ab6380e784214de00fdb"
+checksum = "7ece22da0cbf350e4a2939a07eaa3200445e42e47ce1b1ee6538723b6b40a4d4"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1040,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7b96df3facd26ae58fe0c3c30bd1d8e83c2b7f0b0c9c046800901dc1eff14e"
+checksum = "d84a0e14ce66e76497a6771f3e360eb85557f2417ea22db279d54c1238ffafde"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1063,8 +1010,7 @@ dependencies = [
 [[package]]
 name = "miden-base"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045c36f3099304b5ceddd0ec131975736797c481b74b0b21b228eb265cc2e3a9"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1073,8 +1019,7 @@ dependencies = [
 [[package]]
 name = "miden-base-macros"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4dc05134f25ffb821bdd77026ce04b64e55a575ec9725e7298eedde78c715d"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "heck",
  "miden-protocol",
@@ -1090,8 +1035,7 @@ dependencies = [
 [[package]]
 name = "miden-base-sys"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b705b291476bc2abff3498da84415c7f555d7b28b754677d420d5f2fa1858815"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1099,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cb3c6b071a7a5fc6a10dfbaed76f3d0170f3739a231233a3c5e27596a5612f"
+checksum = "7bf4f5601b0d669aa125cce3bba4b98f2c8df729e2d53e66777429ac5f53e228"
 dependencies = [
  "derive_more",
  "itertools",
@@ -1110,18 +1054,17 @@ dependencies = [
  "miden-formatting",
  "miden-utils-core-derive",
  "miden-utils-indexing",
+ "miden-utils-sync",
  "num-derive",
  "num-traits",
  "thiserror",
- "winter-math",
- "winter-utils",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703c0e94089a3135ba75e3586fcb4e5d61e3bee10a7ee1dad0b2ac0a497c14e9"
+checksum = "82595fabb062315c32f6fc11c31755d3e5c6f8bc8c67d35154a067397d65b1de"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -1130,15 +1073,14 @@ dependencies = [
  "miden-crypto",
  "miden-processor",
  "miden-utils-sync",
- "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.19.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e28b6e110f339c2edc2760a8cb94863f0a055ee658a49bc90c8560eff2feef4"
+checksum = "0ed0a034a460e27723dcfdf25effffab84331c3b46b13e7a1bd674197cc71bfe"
 dependencies = [
  "blake3",
  "cc",
@@ -1150,27 +1092,37 @@ dependencies = [
  "hkdf",
  "k256",
  "miden-crypto-derive",
+ "miden-field 0.23.0",
+ "miden-serde-utils 0.23.0",
  "num",
  "num-complex",
- "rand",
+ "p3-blake3",
+ "p3-challenger 0.5.2",
+ "p3-dft 0.5.2",
+ "p3-goldilocks 0.5.2",
+ "p3-keccak",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-lifted-stark",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_core 0.9.5",
  "rand_hc",
+ "serde",
  "sha2",
  "sha3",
  "subtle",
  "thiserror",
- "winter-crypto",
- "winter-math",
- "winter-utils",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.19.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40e95b9c7c99ed6bbf073d9e02721d812dedd2c195019c0a0e0a3dbb9cbf034"
+checksum = "e8bf6ebde028e79bcc61a3632d2f375a5cc64caa17d014459f75015238cb1e08"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -1178,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb127273a9ee9ac1f9ad71899c1c2a0dea8cf768a90024d2d8b91800980c756"
+checksum = "c9ef08bafef275f0d6a15108108b3f6df6642772e0a1c05e102cb7e96841e888"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1196,29 +1148,53 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.10.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b109845d46982cea10094f196b94e19ee5602d165e47e6b64a4bd08b96b1106e"
+checksum = "546ac41444d6f1ab015daa0bf420759405d3cf0a5cb2b552140ad60443ddf39c"
 dependencies = [
- "miden-core",
+ "miden-serde-utils 0.22.6",
+ "num-bigint",
+ "p3-challenger 0.4.2",
+ "p3-field 0.4.2",
+ "p3-goldilocks 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-field"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
+dependencies = [
+ "miden-serde-utils 0.23.0",
+ "num-bigint",
+ "p3-challenger 0.5.2",
+ "p3-field 0.5.2",
+ "p3-goldilocks 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "subtle",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-field-repr"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e942a969b5cc8bb3c578318660a821f1d0ccf26735f2a86475842337a78eba1d"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-core",
- "miden-field",
+ "miden-field 0.22.6",
  "miden-field-repr-derive",
 ]
 
 [[package]]
 name = "miden-field-repr-derive"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e0942b6867f7d0e19dc34f9e0b83255d768efab844ba46118885c314c4b655"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,13 +1212,14 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7b21cd2593ed5930d5af10b197917dd6668ab34e203e47fb9c1ba712dc9a2c"
+checksum = "f9b24d09fda64e0751f943ac616643342b05a47d626e2ee0040b902eff3c924e"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
  "miden-core",
+ "miden-debug-types",
  "thiserror",
 ]
 
@@ -1252,8 +1229,6 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef536978f24a179d94fa2a41e4f92b28e7d8aab14b8d23df28ad2a3d7098b20"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "futures",
  "indenter",
@@ -1264,13 +1239,9 @@ dependencies = [
  "rustc_version 0.2.3",
  "rustversion",
  "serde_json",
- "spin",
+ "spin 0.9.8",
  "strip-ansi-escapes",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
  "syn 2.0.114",
- "terminal_size",
  "textwrap",
  "thiserror",
  "trybuild",
@@ -1290,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72712c2c71774f7a49d66a0265b57be7a283919ffbdc4b034ab355b0283de021"
+checksum = "ba53ff06ef0affa0c3fb13e7e2ef5bde99f96eebcec8c360c6658050480ef676"
 dependencies = [
  "itertools",
  "miden-air",
@@ -1305,14 +1276,13 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "winter-prover",
 ]
 
 [[package]]
 name = "miden-protocol"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785be319a826c9cb43d2e1a41a1fb1eee3f2baafe360e0d743690641f7c93ad5"
+checksum = "38c30a20ea30071544a827d0daa12e343e444c1e314d1a4560c43f2d6c7b43c6"
 dependencies = [
  "bech32",
  "fs-err",
@@ -1327,7 +1297,7 @@ dependencies = [
  "miden-protocol-macros",
  "miden-utils-sync",
  "miden-verifier",
- "rand",
+ "rand 0.9.2",
  "regex",
  "semver 1.0.27",
  "thiserror",
@@ -1336,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dc854c1b9e49e82d3f39c5710345226e0b2a62ec0ea220c616f1f3a099cfb3"
+checksum = "76c58e1d47dd08af461f6aa13ec128013bb1a26183ea4dd42f323939bcbf72d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1348,23 +1318,41 @@ dependencies = [
 [[package]]
 name = "miden-sdk-alloc"
 version = "0.10.0"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+
+[[package]]
+name = "miden-serde-utils"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2ab739974c7abe0173915532b64b9826b8619fda7a60a45cf9f83f620b581d"
+checksum = "0bedaf94fb4bb6806e4af99fadce74e4cdd0e8664c571107b255f86b00b3149b"
+dependencies = [
+ "p3-field 0.4.2",
+ "p3-goldilocks 0.4.2",
+]
+
+[[package]]
+name = "miden-serde-utils"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-goldilocks 0.5.2",
+]
 
 [[package]]
 name = "miden-stdlib-sys"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed03f52e0c04ceabac37ddacdc286b81fc19140d462993e9e7048f757b203abb"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
- "miden-field",
+ "miden-field 0.22.6",
 ]
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3753ff5c16cb83244d234b7f76fb8abec3377200b215859fe599c41465e7d36b"
+checksum = "477db426fc31f666d7e65b0cc907fe431d36d88d611a0594cf266104eb168b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1373,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6c667538374e6a3579397a29f82d94e62d2f9cf1eca8a95da1a7acbfed381d"
+checksum = "785c1ec4ad9994100b117b8eab8c453dcc35d3d168e4f72ac818efb700abe7b1"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1386,55 +1374,53 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e135423d4d3d626ea15fdfe7070abe5f7908ac71a2d174c832c870668fb2a3"
+checksum = "46cec00c8cf32ec46df7542fb9ea15fbe7a5149920ef97776a4f4bc3a563e8de"
 dependencies = [
+ "miden-crypto",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e678634bd9ce5d6f89809cda926a268bcbfe72aa0a5d2031a0c8182074992"
+checksum = "9529c1c173506f30d3949f7a54b65f1eb318098e37ed5730a1bb9027eee2fa4b"
 dependencies = [
  "lock_api",
  "loom",
+ "once_cell",
  "parking_lot",
 ]
 
 [[package]]
 name = "miden-verifier"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9513494a2a8cd876150bbbb5a2985b078368de280cc8a52e9aff41320c344b7"
+checksum = "997c842047ffa2d011eb65bf638a3135b2d52bce5b20770fcc6040f1b48c624a"
 dependencies = [
+ "bincode",
  "miden-air",
  "miden-core",
+ "miden-crypto",
+ "serde",
  "thiserror",
  "tracing",
- "winter-verifier",
 ]
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.4.3"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4cfab04baffdda3fb9eafa5f873604059b89a1699aa95e4f1057397a69f0b5"
+checksum = "2eb29d7c049fb69373c7e775e3d4411e63e4ee608bc43826282ba62c6ec9f891"
 dependencies = [
  "miden-formatting",
+ "miden-serde-utils 0.23.0",
+ "serde",
+ "serde_repr",
  "smallvec",
  "thiserror",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
 ]
 
 [[package]]
@@ -1458,7 +1444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1547,15 +1533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1555,473 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "p3-air"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "p3-blake3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
+dependencies = [
+ "blake3",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20e42ba74a49c08c6e99f74cd9b343bfa31aa5721fea55079b18e3fd65f1dcbc"
+dependencies = [
+ "p3-field 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-monty-31 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "tracing",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-monty-31 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-util 0.5.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63fa5eb1bd12a240089e72ae3fe10350944d9c166d00a3bfd2a1794db65cf5c"
+dependencies = [
+ "itertools",
+ "p3-field 0.4.2",
+ "p3-matrix 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-util 0.5.2",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ebfdb6ef992ae64e9e8f449ac46516ffa584f11afbdf9ee244288c2a633cdf4"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-maybe-rayon 0.5.2",
+ "p3-util 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64716244b5612622d4e78a4f48b74f6d3bb7b4085b7b6b25364b1dfca7198c66"
+dependencies = [
+ "num-bigint",
+ "p3-challenger 0.4.2",
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-poseidon2 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+dependencies = [
+ "num-bigint",
+ "p3-challenger 0.5.2",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-mds 0.5.2",
+ "p3-poseidon1",
+ "p3-poseidon2 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+]
+
+[[package]]
+name = "p3-keccak"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
+dependencies = [
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5542f96504dae8100c91398fb1e3f5ec669eb9c73d9e0b018a93b5fe32bad230"
+dependencies = [
+ "itertools",
+ "p3-field 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
+ "rand 0.9.2",
+ "serde",
+ "tracing",
+ "transpose",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5669ca75645f99cd001e9d0289a4eeff2bc2cd9dc3c6c3aaf22643966e83df"
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+
+[[package]]
+name = "p3-mds"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038763af23df9da653065867fd85b38626079031576c86fd537097e5be6a0da0"
+dependencies = [
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+dependencies = [
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-miden-lifted-air"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
+dependencies = [
+ "p3-air",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-util 0.5.2",
+ "thiserror",
+]
+
+[[package]]
+name = "p3-miden-lifted-fri"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
+dependencies = [
+ "p3-challenger 0.5.2",
+ "p3-commit",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-lmcs",
+ "p3-miden-transcript",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lifted-stark"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
+dependencies = [
+ "p3-challenger 0.5.2",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-lifted-air",
+ "p3-miden-lifted-fri",
+ "p3-miden-lmcs",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-util 0.5.2",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lmcs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
+dependencies = [
+ "p3-commit",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-stateful-hasher"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-symmetric 0.5.2",
+]
+
+[[package]]
+name = "p3-miden-transcript"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
+dependencies = [
+ "p3-challenger 0.5.2",
+ "p3-field 0.5.2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a981d60da3d8cbf8561014e2c186068578405fd69098fa75b43d4afb364a47"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-matrix 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-poseidon2 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+ "spin 0.10.0",
+ "tracing",
+ "transpose",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-mds 0.5.2",
+ "p3-poseidon1",
+ "p3-poseidon2 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-poseidon1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-symmetric 0.5.2",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903b73e4f9a7781a18561c74dc169cf03333497b57a8dd02aaeb130c0f386599"
+dependencies = [
+ "p3-field 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-mds 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd788f04e86dd5c35dd87cad29eefdb6371d2fd5f7664451382eeacae3c3ed0"
+dependencies = [
+ "itertools",
+ "p3-field 0.4.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-util 0.5.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663b16021930bc600ecada915c6c3965730a3b9d6a6c23434ccf70bfc29d6881"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+dependencies = [
+ "serde",
+ "transpose",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1717,7 +2161,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1750,6 +2194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +2229,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -1864,12 +2323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,19 +2338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.27",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2010,6 +2450,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2535,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"
@@ -2101,6 +2555,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2572,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -2136,27 +2605,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -2192,7 +2640,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2202,16 +2650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
-dependencies = [
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2255,12 +2693,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2403,6 +2862,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -2610,7 +3079,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2630,24 +3099,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2656,222 +3107,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winter-air"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
-dependencies = [
- "libm",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-crypto"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb247bc142438798edb04067ab72a22cf815f57abbd7b78a6fa986fc101db8"
-dependencies = [
- "blake3",
- "sha3",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-fri"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
-dependencies = [
- "winter-crypto",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-math"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aecfb48ee6a8b4746392c8ff31e33e62df8528a3b5628c5af27b92b14aef1ea"
-dependencies = [
- "winter-utils",
-]
-
-[[package]]
-name = "winter-maybe-async"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
-dependencies = [
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "winter-prover"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
-dependencies = [
- "tracing",
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-maybe-async",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
-
-[[package]]
-name = "winter-verifier"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
-dependencies = [
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
 ]
 
 [[package]]

--- a/contracts/counter-account/Cargo.lock
+++ b/contracts/counter-account/Cargo.lock
@@ -945,8 +945,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miden"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010a8120478c5bbffa3ff1f139a01bac789331fbfef5a30f5ee6fd467225d3a2"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1009,8 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cab3453f9574645a7e0ace17aa87998ebe9efde5ae2291ad9a310d6051aa0e"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1018,8 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6389b82f5b125fd5c02fbf057e2d801aed3e4b3a22b73ca27601f5546343abe"
 dependencies = [
  "heck",
  "miden-protocol",
@@ -1034,8 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842a10d5a6f4b4710356c5cd026400eb901f380e4e445e6bfb084985963b0f88"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1183,8 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c87de3a3d7535308e525fb8407defd4e7a169c6af575e148538b83800ffc6d2"
 dependencies = [
  "miden-core",
  "miden-field 0.22.6",
@@ -1193,8 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3f1c00fe41ffa413b0ad36236e1016a64125162703f7be985d79f8dff3f7dba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1317,8 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43d6123657c5ddd606ef3d36bb1bacd345abcfdbc2ca9b0cab8e839e63558f2"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1342,8 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0fad7b45aa92ca52a7fb15b20cb2be0eec1472bd36a1f20cc10d649507919d"
 dependencies = [
  "miden-field 0.22.6",
 ]

--- a/contracts/counter-account/Cargo.toml
+++ b/contracts/counter-account/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# miden = { version = "0.10" }
-miden = { version = "0.10", git = "https://github.com/0xMiden/compiler", branch = "next" }
+miden = { version = "0.11" }
 
 [package.metadata.component]
 package = "miden:counter-account"

--- a/contracts/counter-account/Cargo.toml
+++ b/contracts/counter-account/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-miden = { git = "https://github.com/0xMiden/compiler", rev = "630c65795e44b17d43d2a289009aca96d56f57ee" }
+miden = { version = "0.12" }
 
 [package.metadata.component]
 package = "miden:counter-account"

--- a/contracts/counter-account/Cargo.toml
+++ b/contracts/counter-account/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-miden = { version = "0.10" }
+# miden = { version = "0.10" }
+miden = { version = "0.10", git = "https://github.com/0xMiden/compiler", branch = "next" }
 
 [package.metadata.component]
 package = "miden:counter-account"

--- a/contracts/counter-account/Cargo.toml
+++ b/contracts/counter-account/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-miden = { version = "0.11" }
+miden = { git = "https://github.com/0xMiden/compiler", rev = "630c65795e44b17d43d2a289009aca96d56f57ee" }
 
 [package.metadata.component]
 package = "miden:counter-account"

--- a/contracts/counter-account/src/lib.rs
+++ b/contracts/counter-account/src/lib.rs
@@ -7,14 +7,14 @@
 //
 // extern crate alloc;
 
-use miden::{component, felt, Felt, StorageMap, StorageMapAccess, Word};
+use miden::{component, felt, Felt, StorageMap, Word};
 
 /// Main contract structure for the counter example.
 #[component]
 struct CounterContract {
     /// Storage map holding the counter value.
     #[storage(description = "counter contract storage map")]
-    count_map: StorageMap,
+    count_map: StorageMap<Word, Felt>,
 }
 
 #[component]
@@ -22,17 +22,17 @@ impl CounterContract {
     /// Returns the current counter value stored in the contract's storage map.
     pub fn get_count(&self) -> Felt {
         // Define a fixed key for the counter value within the map
-        let key = Word::from_u64_unchecked(0, 0, 0, 1);
+        let key = Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]);
         // Read the value associated with the key from the storage map
-        self.count_map.get(&key)
+        self.count_map.get(key)
     }
 
     /// Increments the counter value stored in the contract's storage map by one.
     pub fn increment_count(&mut self) -> Felt {
         // Define the same fixed key
-        let key = Word::from_u64_unchecked(0, 0, 0, 1);
+        let key = Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]);
         // Read the current value
-        let current_value: Felt = self.count_map.get(&key);
+        let current_value: Felt = self.count_map.get(key);
         // Increment the value by one
         let new_value = current_value + felt!(1);
         // Write the new value back to the storage map

--- a/contracts/increment-note/Cargo.lock
+++ b/contracts/increment-note/Cargo.lock
@@ -945,8 +945,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miden"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76174f46c7bd1aaf25163cb6c4cf6d9bdb1993d5466ba543c1d6c343a080b767"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1009,8 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45eaf65ed9fc03898e162c9ff9649079568075543a7bcac474f3befe1ec10ad2"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1018,8 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52bebbd631f689028da59d3c1259cb1e8309e9c59cf0a9a625a98e057bebdfe"
 dependencies = [
  "heck",
  "miden-formatting",
@@ -1036,8 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c8466611116cc47e620705c32624d9a4de0dd777ef95f03219d5580e93bcaf"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1185,8 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dba0d085dfb109ebe2a9a6b1acb014f417ae8bfebb17845991ba1c215036822"
 dependencies = [
  "miden-core",
  "miden-field 0.22.6",
@@ -1195,8 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489216f38e837d9b9a1ad66524649b92ab0fcd7d90662e52952fc56e8703d305"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1319,8 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65e9824b7e7297619902c6cb73d71db08434ac07a24ca5a167e8647352698c2e"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1344,8 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.11.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44231388ca9ed654bc84e71ff2daca69fb353997066bdf8ebe19b1cf80330b53"
 dependencies = [
  "miden-field 0.22.6",
 ]
@@ -1413,8 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-frontend-wasm-metadata"
-version = "0.8.0"
-source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6938fd4efb4a2c8937c77055a3779ddda33572728328cf4391d2f240f78be3a"
 dependencies = [
  "serde",
  "serde_json",

--- a/contracts/increment-note/Cargo.lock
+++ b/contracts/increment-note/Cargo.lock
@@ -946,8 +946,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "miden"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010a8120478c5bbffa3ff1f139a01bac789331fbfef5a30f5ee6fd467225d3a2"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1011,8 +1010,7 @@ dependencies = [
 [[package]]
 name = "miden-base"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cab3453f9574645a7e0ace17aa87998ebe9efde5ae2291ad9a310d6051aa0e"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1021,11 +1019,12 @@ dependencies = [
 [[package]]
 name = "miden-base-macros"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6389b82f5b125fd5c02fbf057e2d801aed3e4b3a22b73ca27601f5546343abe"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "heck",
+ "miden-formatting",
  "miden-protocol",
+ "midenc-frontend-wasm-metadata",
  "proc-macro2",
  "quote",
  "semver 1.0.27",
@@ -1038,8 +1037,7 @@ dependencies = [
 [[package]]
 name = "miden-base-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842a10d5a6f4b4710356c5cd026400eb901f380e4e445e6bfb084985963b0f88"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1188,8 +1186,7 @@ dependencies = [
 [[package]]
 name = "miden-field-repr"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c87de3a3d7535308e525fb8407defd4e7a169c6af575e148538b83800ffc6d2"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-core",
  "miden-field 0.22.6",
@@ -1199,8 +1196,7 @@ dependencies = [
 [[package]]
 name = "miden-field-repr-derive"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f1c00fe41ffa413b0ad36236e1016a64125162703f7be985d79f8dff3f7dba"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1324,8 +1320,7 @@ dependencies = [
 [[package]]
 name = "miden-sdk-alloc"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43d6123657c5ddd606ef3d36bb1bacd345abcfdbc2ca9b0cab8e839e63558f2"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1350,8 +1345,7 @@ dependencies = [
 [[package]]
 name = "miden-stdlib-sys"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0fad7b45aa92ca52a7fb15b20cb2be0eec1472bd36a1f20cc10d649507919d"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
 dependencies = [
  "miden-field 0.22.6",
 ]
@@ -1415,6 +1409,15 @@ dependencies = [
  "serde",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "midenc-frontend-wasm-metadata"
+version = "0.8.0"
+source = "git+https://github.com/0xMiden/compiler?rev=630c65795e44b17d43d2a289009aca96d56f57ee#630c65795e44b17d43d2a289009aca96d56f57ee"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/contracts/increment-note/Cargo.lock
+++ b/contracts/increment-note/Cargo.lock
@@ -3,21 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,7 +57,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -83,7 +68,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -120,30 +105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
-
-[[package]]
-name = "backtrace-ext"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +121,15 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -315,6 +285,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -518,16 +494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,7 +530,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -697,12 +663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,12 +757,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "is_ci"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -947,12 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,13 +946,12 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 [[package]]
 name = "miden"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ecb2c6a5ccd0834bfe0b7fb09e4d4bbf7f9228b3739cbb9dc5777df39e0989"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-base",
  "miden-base-macros",
  "miden-base-sys",
- "miden-field",
+ "miden-field 0.22.6",
  "miden-field-repr",
  "miden-sdk-alloc",
  "miden-stdlib-sys",
@@ -1013,22 +960,22 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33eacdeeaf50a704b221efe81abf1f1e9870154c5bd4acc11f5ad3f872e73509"
+checksum = "5322d00bef8b19f4cd3415da2533a87c8860c7d9b80043d6cce0f184b40c5fff"
 dependencies = [
  "miden-core",
+ "miden-crypto",
  "miden-utils-indexing",
  "thiserror",
- "winter-air",
- "winter-prover",
+ "tracing",
 ]
 
 [[package]]
 name = "miden-assembly"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdebc6a73964aaf92179d9a9925ca48d662894f24774ab6380e784214de00fdb"
+checksum = "7ece22da0cbf350e4a2939a07eaa3200445e42e47ce1b1ee6538723b6b40a4d4"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1040,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7b96df3facd26ae58fe0c3c30bd1d8e83c2b7f0b0c9c046800901dc1eff14e"
+checksum = "d84a0e14ce66e76497a6771f3e360eb85557f2417ea22db279d54c1238ffafde"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -1063,8 +1010,7 @@ dependencies = [
 [[package]]
 name = "miden-base"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045c36f3099304b5ceddd0ec131975736797c481b74b0b21b228eb265cc2e3a9"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1073,8 +1019,7 @@ dependencies = [
 [[package]]
 name = "miden-base-macros"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4dc05134f25ffb821bdd77026ce04b64e55a575ec9725e7298eedde78c715d"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "heck",
  "miden-protocol",
@@ -1090,8 +1035,7 @@ dependencies = [
 [[package]]
 name = "miden-base-sys"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b705b291476bc2abff3498da84415c7f555d7b28b754677d420d5f2fa1858815"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1099,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cb3c6b071a7a5fc6a10dfbaed76f3d0170f3739a231233a3c5e27596a5612f"
+checksum = "7bf4f5601b0d669aa125cce3bba4b98f2c8df729e2d53e66777429ac5f53e228"
 dependencies = [
  "derive_more",
  "itertools",
@@ -1110,18 +1054,17 @@ dependencies = [
  "miden-formatting",
  "miden-utils-core-derive",
  "miden-utils-indexing",
+ "miden-utils-sync",
  "num-derive",
  "num-traits",
  "thiserror",
- "winter-math",
- "winter-utils",
 ]
 
 [[package]]
 name = "miden-core-lib"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703c0e94089a3135ba75e3586fcb4e5d61e3bee10a7ee1dad0b2ac0a497c14e9"
+checksum = "82595fabb062315c32f6fc11c31755d3e5c6f8bc8c67d35154a067397d65b1de"
 dependencies = [
  "env_logger",
  "fs-err",
@@ -1130,15 +1073,14 @@ dependencies = [
  "miden-crypto",
  "miden-processor",
  "miden-utils-sync",
- "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-crypto"
-version = "0.19.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e28b6e110f339c2edc2760a8cb94863f0a055ee658a49bc90c8560eff2feef4"
+checksum = "0ed0a034a460e27723dcfdf25effffab84331c3b46b13e7a1bd674197cc71bfe"
 dependencies = [
  "blake3",
  "cc",
@@ -1150,27 +1092,37 @@ dependencies = [
  "hkdf",
  "k256",
  "miden-crypto-derive",
+ "miden-field 0.23.0",
+ "miden-serde-utils 0.23.0",
  "num",
  "num-complex",
- "rand",
+ "p3-blake3",
+ "p3-challenger 0.5.2",
+ "p3-dft 0.5.2",
+ "p3-goldilocks 0.5.2",
+ "p3-keccak",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-lifted-stark",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_core 0.9.5",
  "rand_hc",
+ "serde",
  "sha2",
  "sha3",
  "subtle",
  "thiserror",
- "winter-crypto",
- "winter-math",
- "winter-utils",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.19.4"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40e95b9c7c99ed6bbf073d9e02721d812dedd2c195019c0a0e0a3dbb9cbf034"
+checksum = "e8bf6ebde028e79bcc61a3632d2f375a5cc64caa17d014459f75015238cb1e08"
 dependencies = [
  "quote",
  "syn 2.0.114",
@@ -1178,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb127273a9ee9ac1f9ad71899c1c2a0dea8cf768a90024d2d8b91800980c756"
+checksum = "c9ef08bafef275f0d6a15108108b3f6df6642772e0a1c05e102cb7e96841e888"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1196,29 +1148,53 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.10.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b109845d46982cea10094f196b94e19ee5602d165e47e6b64a4bd08b96b1106e"
+checksum = "546ac41444d6f1ab015daa0bf420759405d3cf0a5cb2b552140ad60443ddf39c"
 dependencies = [
- "miden-core",
+ "miden-serde-utils 0.22.6",
+ "num-bigint",
+ "p3-challenger 0.4.2",
+ "p3-field 0.4.2",
+ "p3-goldilocks 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-field"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38011348f4fb4c9e5ce1f471203d024721c00e3b60a91aa91aaefe6738d8b5ea"
+dependencies = [
+ "miden-serde-utils 0.23.0",
+ "num-bigint",
+ "p3-challenger 0.5.2",
+ "p3-field 0.5.2",
+ "p3-goldilocks 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "subtle",
+ "thiserror",
 ]
 
 [[package]]
 name = "miden-field-repr"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e942a969b5cc8bb3c578318660a821f1d0ccf26735f2a86475842337a78eba1d"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "miden-core",
- "miden-field",
+ "miden-field 0.22.6",
  "miden-field-repr-derive",
 ]
 
 [[package]]
 name = "miden-field-repr-derive"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e0942b6867f7d0e19dc34f9e0b83255d768efab844ba46118885c314c4b655"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,13 +1212,14 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7b21cd2593ed5930d5af10b197917dd6668ab34e203e47fb9c1ba712dc9a2c"
+checksum = "f9b24d09fda64e0751f943ac616643342b05a47d626e2ee0040b902eff3c924e"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
  "miden-core",
+ "miden-debug-types",
  "thiserror",
 ]
 
@@ -1252,8 +1229,6 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef536978f24a179d94fa2a41e4f92b28e7d8aab14b8d23df28ad2a3d7098b20"
 dependencies = [
- "backtrace",
- "backtrace-ext",
  "cfg-if",
  "futures",
  "indenter",
@@ -1264,13 +1239,9 @@ dependencies = [
  "rustc_version 0.2.3",
  "rustversion",
  "serde_json",
- "spin",
+ "spin 0.9.8",
  "strip-ansi-escapes",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
  "syn 2.0.114",
- "terminal_size",
  "textwrap",
  "thiserror",
  "trybuild",
@@ -1290,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72712c2c71774f7a49d66a0265b57be7a283919ffbdc4b034ab355b0283de021"
+checksum = "ba53ff06ef0affa0c3fb13e7e2ef5bde99f96eebcec8c360c6658050480ef676"
 dependencies = [
  "itertools",
  "miden-air",
@@ -1305,14 +1276,13 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "winter-prover",
 ]
 
 [[package]]
 name = "miden-protocol"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785be319a826c9cb43d2e1a41a1fb1eee3f2baafe360e0d743690641f7c93ad5"
+checksum = "38c30a20ea30071544a827d0daa12e343e444c1e314d1a4560c43f2d6c7b43c6"
 dependencies = [
  "bech32",
  "fs-err",
@@ -1327,7 +1297,7 @@ dependencies = [
  "miden-protocol-macros",
  "miden-utils-sync",
  "miden-verifier",
- "rand",
+ "rand 0.9.2",
  "regex",
  "semver 1.0.27",
  "thiserror",
@@ -1336,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "miden-protocol-macros"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dc854c1b9e49e82d3f39c5710345226e0b2a62ec0ea220c616f1f3a099cfb3"
+checksum = "76c58e1d47dd08af461f6aa13ec128013bb1a26183ea4dd42f323939bcbf72d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1348,23 +1318,41 @@ dependencies = [
 [[package]]
 name = "miden-sdk-alloc"
 version = "0.10.0"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+
+[[package]]
+name = "miden-serde-utils"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2ab739974c7abe0173915532b64b9826b8619fda7a60a45cf9f83f620b581d"
+checksum = "0bedaf94fb4bb6806e4af99fadce74e4cdd0e8664c571107b255f86b00b3149b"
+dependencies = [
+ "p3-field 0.4.2",
+ "p3-goldilocks 0.4.2",
+]
+
+[[package]]
+name = "miden-serde-utils"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff78082e9b4ca89863e68da01b35f8a4029ee6fd912e39fa41fde4273a7debab"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-goldilocks 0.5.2",
+]
 
 [[package]]
 name = "miden-stdlib-sys"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed03f52e0c04ceabac37ddacdc286b81fc19140d462993e9e7048f757b203abb"
+source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
 dependencies = [
- "miden-field",
+ "miden-field 0.22.6",
 ]
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3753ff5c16cb83244d234b7f76fb8abec3377200b215859fe599c41465e7d36b"
+checksum = "477db426fc31f666d7e65b0cc907fe431d36d88d611a0594cf266104eb168b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1373,9 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6c667538374e6a3579397a29f82d94e62d2f9cf1eca8a95da1a7acbfed381d"
+checksum = "785c1ec4ad9994100b117b8eab8c453dcc35d3d168e4f72ac818efb700abe7b1"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1386,55 +1374,53 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e135423d4d3d626ea15fdfe7070abe5f7908ac71a2d174c832c870668fb2a3"
+checksum = "46cec00c8cf32ec46df7542fb9ea15fbe7a5149920ef97776a4f4bc3a563e8de"
 dependencies = [
+ "miden-crypto",
  "thiserror",
 ]
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e678634bd9ce5d6f89809cda926a268bcbfe72aa0a5d2031a0c8182074992"
+checksum = "9529c1c173506f30d3949f7a54b65f1eb318098e37ed5730a1bb9027eee2fa4b"
 dependencies = [
  "lock_api",
  "loom",
+ "once_cell",
  "parking_lot",
 ]
 
 [[package]]
 name = "miden-verifier"
-version = "0.20.5"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9513494a2a8cd876150bbbb5a2985b078368de280cc8a52e9aff41320c344b7"
+checksum = "997c842047ffa2d011eb65bf638a3135b2d52bce5b20770fcc6040f1b48c624a"
 dependencies = [
+ "bincode",
  "miden-air",
  "miden-core",
+ "miden-crypto",
+ "serde",
  "thiserror",
  "tracing",
- "winter-verifier",
 ]
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.4.3"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4cfab04baffdda3fb9eafa5f873604059b89a1699aa95e4f1057397a69f0b5"
+checksum = "2eb29d7c049fb69373c7e775e3d4411e63e4ee608bc43826282ba62c6ec9f891"
 dependencies = [
  "miden-formatting",
+ "miden-serde-utils 0.23.0",
+ "serde",
+ "serde_repr",
  "smallvec",
  "thiserror",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
 ]
 
 [[package]]
@@ -1458,7 +1444,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1547,15 +1533,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1555,473 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "p3-air"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "p3-blake3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
+dependencies = [
+ "blake3",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20e42ba74a49c08c6e99f74cd9b343bfa31aa5721fea55079b18e3fd65f1dcbc"
+dependencies = [
+ "p3-field 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-monty-31 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "tracing",
+]
+
+[[package]]
+name = "p3-challenger"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-monty-31 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "p3-commit"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916ae7989d5c3b49f887f5c55b2f9826bdbb81aaebf834503c4145d8b267c829"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-util 0.5.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63fa5eb1bd12a240089e72ae3fe10350944d9c166d00a3bfd2a1794db65cf5c"
+dependencies = [
+ "itertools",
+ "p3-field 0.4.2",
+ "p3-matrix 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-dft"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-util 0.5.2",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ebfdb6ef992ae64e9e8f449ac46516ffa584f11afbdf9ee244288c2a633cdf4"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-field"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-maybe-rayon 0.5.2",
+ "p3-util 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64716244b5612622d4e78a4f48b74f6d3bb7b4085b7b6b25364b1dfca7198c66"
+dependencies = [
+ "num-bigint",
+ "p3-challenger 0.4.2",
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-poseidon2 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-goldilocks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+dependencies = [
+ "num-bigint",
+ "p3-challenger 0.5.2",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-mds 0.5.2",
+ "p3-poseidon1",
+ "p3-poseidon2 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+]
+
+[[package]]
+name = "p3-keccak"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
+dependencies = [
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5542f96504dae8100c91398fb1e3f5ec669eb9c73d9e0b018a93b5fe32bad230"
+dependencies = [
+ "itertools",
+ "p3-field 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-util 0.4.2",
+ "rand 0.9.2",
+ "serde",
+ "tracing",
+ "transpose",
+]
+
+[[package]]
+name = "p3-matrix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5669ca75645f99cd001e9d0289a4eeff2bc2cd9dc3c6c3aaf22643966e83df"
+
+[[package]]
+name = "p3-maybe-rayon"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+
+[[package]]
+name = "p3-mds"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038763af23df9da653065867fd85b38626079031576c86fd537097e5be6a0da0"
+dependencies = [
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "p3-mds"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+dependencies = [
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-miden-lifted-air"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c31c65fdc88952d7b301546add9670676e5b878aa0066dd929f107c203b006"
+dependencies = [
+ "p3-air",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-util 0.5.2",
+ "thiserror",
+]
+
+[[package]]
+name = "p3-miden-lifted-fri"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9932f1b0a16609a45cd4ee10a4d35412728bc4b38837c7979d7c85d8dcc9fc"
+dependencies = [
+ "p3-challenger 0.5.2",
+ "p3-commit",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-lmcs",
+ "p3-miden-transcript",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lifted-stark"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3956ab7270c3cdd53ca9796d39ae1821984eb977415b0672110f9666bff5d8"
+dependencies = [
+ "p3-challenger 0.5.2",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-lifted-air",
+ "p3-miden-lifted-fri",
+ "p3-miden-lmcs",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-util 0.5.2",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-lmcs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c46791c983e772136db3d48f102431457451447abb9087deb6c8ce3c1efc86"
+dependencies = [
+ "p3-commit",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-miden-stateful-hasher",
+ "p3-miden-transcript",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "p3-miden-stateful-hasher"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec47a9d9615eb3d9d2a59b00d19751d9ad85384b55886827913d680d912eac6a"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-symmetric 0.5.2",
+]
+
+[[package]]
+name = "p3-miden-transcript"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c565647487e4a949f67e6f115b0391d6cb82ac8e561165789939bab23d0ae7"
+dependencies = [
+ "p3-challenger 0.5.2",
+ "p3-field 0.5.2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a981d60da3d8cbf8561014e2c186068578405fd69098fa75b43d4afb364a47"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-dft 0.4.2",
+ "p3-field 0.4.2",
+ "p3-matrix 0.4.2",
+ "p3-maybe-rayon 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-poseidon2 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "paste",
+ "rand 0.9.2",
+ "serde",
+ "spin 0.10.0",
+ "tracing",
+ "transpose",
+]
+
+[[package]]
+name = "p3-monty-31"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+dependencies = [
+ "itertools",
+ "num-bigint",
+ "p3-dft 0.5.2",
+ "p3-field 0.5.2",
+ "p3-matrix 0.5.2",
+ "p3-maybe-rayon 0.5.2",
+ "p3-mds 0.5.2",
+ "p3-poseidon1",
+ "p3-poseidon2 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "paste",
+ "rand 0.10.0",
+ "serde",
+ "spin 0.10.0",
+ "tracing",
+]
+
+[[package]]
+name = "p3-poseidon1"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-symmetric 0.5.2",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903b73e4f9a7781a18561c74dc169cf03333497b57a8dd02aaeb130c0f386599"
+dependencies = [
+ "p3-field 0.4.2",
+ "p3-mds 0.4.2",
+ "p3-symmetric 0.4.2",
+ "p3-util 0.4.2",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "p3-poseidon2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+dependencies = [
+ "p3-field 0.5.2",
+ "p3-mds 0.5.2",
+ "p3-symmetric 0.5.2",
+ "p3-util 0.5.2",
+ "rand 0.10.0",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd788f04e86dd5c35dd87cad29eefdb6371d2fd5f7664451382eeacae3c3ed0"
+dependencies = [
+ "itertools",
+ "p3-field 0.4.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-symmetric"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+dependencies = [
+ "itertools",
+ "p3-field 0.5.2",
+ "p3-util 0.5.2",
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "663b16021930bc600ecada915c6c3965730a3b9d6a6c23434ccf70bfc29d6881"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "p3-util"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+dependencies = [
+ "serde",
+ "transpose",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1717,7 +2161,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1750,6 +2194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +2229,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_hc"
@@ -1864,12 +2323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,19 +2338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.27",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2010,6 +2450,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2084,6 +2535,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smawk"
@@ -2101,6 +2555,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2572,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -2136,27 +2605,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
-dependencies = [
- "is_ci",
-]
-
-[[package]]
-name = "supports-hyperlinks"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
-
-[[package]]
-name = "supports-unicode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -2192,7 +2640,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2202,16 +2650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
-dependencies = [
- "rustix",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2255,12 +2693,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2403,6 +2862,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
 ]
 
 [[package]]
@@ -2610,7 +3079,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2630,24 +3099,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2656,222 +3107,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winter-air"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01227f23c7c331710f43b877a8333f5f8d539631eea763600f1a74bf018c7c"
-dependencies = [
- "libm",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-crypto"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cdb247bc142438798edb04067ab72a22cf815f57abbd7b78a6fa986fc101db8"
-dependencies = [
- "blake3",
- "sha3",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-fri"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd592b943f9d65545683868aaf1b601eb66e52bfd67175347362efff09101d3a"
-dependencies = [
- "winter-crypto",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-math"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aecfb48ee6a8b4746392c8ff31e33e62df8528a3b5628c5af27b92b14aef1ea"
-dependencies = [
- "winter-utils",
-]
-
-[[package]]
-name = "winter-maybe-async"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
-dependencies = [
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "winter-prover"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cc631ed56cd39b78ef932c1ec4060cc6a44d114474291216c32f56655b3048"
-dependencies = [
- "tracing",
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-maybe-async",
- "winter-utils",
-]
-
-[[package]]
-name = "winter-utils"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9951263ef5317740cd0f49e618db00c72fabb70b75756ea26c4d5efe462c04dd"
-
-[[package]]
-name = "winter-verifier"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0425ea81f8f703a1021810216da12003175c7974a584660856224df04b2e2fdb"
-dependencies = [
- "winter-air",
- "winter-crypto",
- "winter-fri",
- "winter-math",
- "winter-utils",
 ]
 
 [[package]]

--- a/contracts/increment-note/Cargo.lock
+++ b/contracts/increment-note/Cargo.lock
@@ -945,8 +945,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miden"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010a8120478c5bbffa3ff1f139a01bac789331fbfef5a30f5ee6fd467225d3a2"
 dependencies = [
  "miden-base",
  "miden-base-macros",
@@ -1009,8 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cab3453f9574645a7e0ace17aa87998ebe9efde5ae2291ad9a310d6051aa0e"
 dependencies = [
  "miden-base-sys",
  "miden-stdlib-sys",
@@ -1018,8 +1020,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-macros"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6389b82f5b125fd5c02fbf057e2d801aed3e4b3a22b73ca27601f5546343abe"
 dependencies = [
  "heck",
  "miden-protocol",
@@ -1034,8 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "miden-base-sys"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842a10d5a6f4b4710356c5cd026400eb901f380e4e445e6bfb084985963b0f88"
 dependencies = [
  "miden-field-repr",
  "miden-stdlib-sys",
@@ -1183,8 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c87de3a3d7535308e525fb8407defd4e7a169c6af575e148538b83800ffc6d2"
 dependencies = [
  "miden-core",
  "miden-field 0.22.6",
@@ -1193,8 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "miden-field-repr-derive"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3f1c00fe41ffa413b0ad36236e1016a64125162703f7be985d79f8dff3f7dba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1317,8 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "miden-sdk-alloc"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e43d6123657c5ddd606ef3d36bb1bacd345abcfdbc2ca9b0cab8e839e63558f2"
 
 [[package]]
 name = "miden-serde-utils"
@@ -1342,8 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib-sys"
-version = "0.10.0"
-source = "git+https://github.com/0xMiden/compiler?branch=next#94aab041a37d12115b485f6f113e822d52854481"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0fad7b45aa92ca52a7fb15b20cb2be0eec1472bd36a1f20cc10d649507919d"
 dependencies = [
  "miden-field 0.22.6",
 ]

--- a/contracts/increment-note/Cargo.toml
+++ b/contracts/increment-note/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-# miden = { version = "0.10" }
-miden = { version = "0.10", git = "https://github.com/0xMiden/compiler", branch = "next" }
+miden = { version = "0.11" }
 
 [package.metadata.component]
 package = "miden:increment-note"

--- a/contracts/increment-note/Cargo.toml
+++ b/contracts/increment-note/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-miden = { version = "0.11" }
+miden = { git = "https://github.com/0xMiden/compiler", rev = "630c65795e44b17d43d2a289009aca96d56f57ee" }
 
 [package.metadata.component]
 package = "miden:increment-note"

--- a/contracts/increment-note/Cargo.toml
+++ b/contracts/increment-note/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-miden = { git = "https://github.com/0xMiden/compiler", rev = "630c65795e44b17d43d2a289009aca96d56f57ee" }
+miden = { version = "0.12" }
 
 [package.metadata.component]
 package = "miden:increment-note"

--- a/contracts/increment-note/Cargo.toml
+++ b/contracts/increment-note/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-miden = { version = "0.10" }
+# miden = { version = "0.10" }
+miden = { version = "0.10", git = "https://github.com/0xMiden/compiler", branch = "next" }
 
 [package.metadata.component]
 package = "miden:increment-note"

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -6,9 +6,10 @@ edition.workspace = true
 [dependencies]
 # cargo-miden = { version = "0.8" }
 # TODO: switch to v0.9 after the compiler release
-cargo-miden = { version = "0.8", git = "https://github.com/0xMiden/compiler", branch = "next"}
+cargo-miden = { version = "0.8", git = "https://github.com/0xMiden/compiler", rev = "630c65795e44b17d43d2a289009aca96d56f57ee"} # next branch
 miden-client = { version = "0.14", features = ["tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
+miden-standards = { version = "0.14", features = ["testing"] }
 miden-testing = "0.14"
 miden-mast-package = { version = "0.22", default-features = false }
 tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-cargo-miden = { version = "0.8" }
+# cargo-miden = { version = "0.8" }
+# TODO: switch to v0.9 after the compiler release
+cargo-miden = { version = "0.8", git = "https://github.com/0xMiden/compiler", branch = "next"}
 miden-client = { version = "0.14", features = ["tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-testing = "0.14"

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -7,8 +7,6 @@ edition.workspace = true
 cargo-miden = { version = "0.7" }
 miden-client = { version = "0.13", features = ["tonic", "testing"] }
 miden-client-sqlite-store = { version = "0.13", package = "miden-client-sqlite-store" }
-miden-standards = { version = "0.13", default-features = false, features = ["testing"] }
-miden-core = { version = "0.20" }
 miden-testing = "0.13"
 miden-mast-package = { version = "0.20", default-features = false }
 tokio = { version = "1.40", features = ["rt-multi-thread", "net", "macros", "fs"] }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -4,11 +4,17 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-cargo-miden = { version = "0.7" }
-miden-client = { version = "0.13", features = ["tonic", "testing"] }
-miden-client-sqlite-store = { version = "0.13", package = "miden-client-sqlite-store" }
-miden-testing = "0.13"
-miden-mast-package = { version = "0.20", default-features = false }
-tokio = { version = "1.40", features = ["rt-multi-thread", "net", "macros", "fs"] }
+# TODO: switch to the v0.8 release
+# cargo-miden = { version = "0.7" }
+cargo-miden = { version = "0.7", git = "https://github.com/0xMiden/compiler", branch = "next"}
+
+# TODO: switch to the v0.14 release
+# miden-client = { version = "0.14", features = ["tonic", "testing"] }
+# miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
+miden-client = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta", features = ["tonic"] }
+miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta", package = "miden-client-sqlite-store"}
+miden-testing = "0.14"
+miden-mast-package = { version = "0.22", default-features = false }
+tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }
 rand = { version = "0.9" }
 anyhow = "1.0"

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -4,15 +4,13 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-# TODO: switch to the v0.8 release
-# cargo-miden = { version = "0.7" }
-cargo-miden = { version = "0.7", git = "https://github.com/0xMiden/compiler", branch = "next"}
+cargo-miden = { version = "0.8" }
 
 # TODO: switch to the v0.14 release
 # miden-client = { version = "0.14", features = ["tonic", "testing"] }
 # miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
-miden-client = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta", features = ["tonic"] }
-miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client", branch = "release/v0.14.0-beta", package = "miden-client-sqlite-store"}
+miden-client = { git = "https://github.com/0xMiden/miden-client", ref = "9aa6d0c0d23ebe0fb1c4d2df7a0d085a802d81bb", features = ["tonic"] }
+miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client", ref = "9aa6d0c0d23ebe0fb1c4d2df7a0d085a802d81bb", package = "miden-client-sqlite-store"}
 miden-testing = "0.14"
 miden-mast-package = { version = "0.22", default-features = false }
 tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-# cargo-miden = { version = "0.8" }
-# TODO: switch to v0.9 after the compiler release
-cargo-miden = { version = "0.8", git = "https://github.com/0xMiden/compiler", rev = "630c65795e44b17d43d2a289009aca96d56f57ee"} # next branch
+cargo-miden = { version = "0.8" }
 miden-client = { version = "0.14", features = ["tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-standards = { version = "0.14", features = ["testing"] }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -5,12 +5,8 @@ edition.workspace = true
 
 [dependencies]
 cargo-miden = { version = "0.8" }
-
-# TODO: switch to the v0.14 release
-# miden-client = { version = "0.14", features = ["tonic", "testing"] }
-# miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
-miden-client = { git = "https://github.com/0xMiden/miden-client", ref = "9aa6d0c0d23ebe0fb1c4d2df7a0d085a802d81bb", features = ["tonic"] }
-miden-client-sqlite-store = { git = "https://github.com/0xMiden/miden-client", ref = "9aa6d0c0d23ebe0fb1c4d2df7a0d085a802d81bb", package = "miden-client-sqlite-store"}
+miden-client = { version = "0.14", features = ["tonic"] }
+miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-testing = "0.14"
 miden-mast-package = { version = "0.22", default-features = false }
 tokio = { version = "1.48", features = ["rt-multi-thread", "net", "macros", "fs"] }

--- a/integration/src/bin/increment_count.rs
+++ b/integration/src/bin/increment_count.rs
@@ -5,8 +5,8 @@ use integration::helpers::{
 
 use anyhow::{Context, Result};
 use miden_client::{
-    account::{StorageMap, StorageSlot, StorageSlotName},
-    transaction::{OutputNote, TransactionRequestBuilder},
+    account::{StorageMap, StorageMapKey, StorageSlot, StorageSlotName},
+    transaction::TransactionRequestBuilder,
     Felt, Word,
 };
 use std::{path::Path, sync::Arc};
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         StorageSlotName::new("miden::component::miden_counter_account::count_map").unwrap();
     let storage_slots = vec![StorageSlot::with_map(
         counter_storage_slot.clone(),
-        StorageMap::with_entries([(count_storage_key, initial_count)]).unwrap(),
+        StorageMap::with_entries([(StorageMapKey::new(count_storage_key), initial_count)]).unwrap(),
     )];
     let counter_cfg = AccountCreationConfig {
         storage_slots,
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
 
     // build and submit transaction to publish note
     let note_publish_request = TransactionRequestBuilder::new()
-        .own_output_notes(vec![OutputNote::Full(counter_note.clone())])
+        .own_output_notes(vec![counter_note.clone()])
         .build()
         .context("Failed to build note publish transaction request")?;
 

--- a/integration/src/bin/increment_count.rs
+++ b/integration/src/bin/increment_count.rs
@@ -1,14 +1,11 @@
 use integration::helpers::{
-    build_project_in_dir, create_account_from_package, create_basic_wallet_account, setup_client,
-    AccountCreationConfig, ClientSetup,
+    build_project_in_dir, counter_storage_slot, create_account_from_package,
+    create_basic_wallet_account, setup_client, AccountCreationConfig, ClientSetup,
+    COUNTER_STORAGE_KEY,
 };
 
 use anyhow::{Context, Result};
-use miden_client::{
-    account::{StorageMap, StorageMapKey, StorageSlot, StorageSlotName},
-    transaction::TransactionRequestBuilder,
-    Felt, Word,
-};
+use miden_client::{account::component::InitStorageData, transaction::TransactionRequestBuilder};
 use miden_standards::testing::note::NoteBuilder;
 use std::{path::Path, sync::Arc};
 
@@ -33,19 +30,14 @@ async fn main() -> Result<()> {
             .context("Failed to build increment note contract")?,
     );
 
-    // Create the counter account with initial storage and no-auth auth component
-    let count_storage_key = Word::from([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(1)]);
-    let initial_count = Word::from([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(0)]);
-    // The slot name is constructed as
-    // `miden::component::[to_underscore(Cargo.toml:package.metadata.component.package)]::[field_name]`
-    let counter_storage_slot =
-        StorageSlotName::new("miden::component::miden_counter_account::count_map").unwrap();
-    let storage_slots = vec![StorageSlot::with_map(
-        counter_storage_slot.clone(),
-        StorageMap::with_entries([(StorageMapKey::new(count_storage_key), initial_count)]).unwrap(),
-    )];
+    // Create the counter account with initial component storage.
+    let counter_storage_slot = counter_storage_slot()?;
+    let mut init_storage_data = InitStorageData::default();
+    init_storage_data
+        .insert_map_entry(counter_storage_slot, COUNTER_STORAGE_KEY, 0_u64)
+        .context("Failed to seed counter storage")?;
     let counter_cfg = AccountCreationConfig {
-        storage_slots,
+        init_storage_data,
         ..Default::default()
     };
 

--- a/integration/src/bin/increment_count.rs
+++ b/integration/src/bin/increment_count.rs
@@ -95,10 +95,5 @@ async fn main() -> Result<()> {
 
     println!("Consume transaction ID: {:?}", consume_tx_id.to_hex());
 
-    // println!(
-    //     "Account delta: {:?}",
-    //     consume_note_request.
-    // );
-
     Ok(())
 }

--- a/integration/src/bin/increment_count.rs
+++ b/integration/src/bin/increment_count.rs
@@ -1,6 +1,6 @@
 use integration::helpers::{
-    build_project_in_dir, create_account_from_package, create_basic_wallet_account,
-    create_note_from_package, setup_client, AccountCreationConfig, ClientSetup, NoteCreationConfig,
+    build_project_in_dir, create_account_from_package, create_basic_wallet_account, setup_client,
+    AccountCreationConfig, ClientSetup,
 };
 
 use anyhow::{Context, Result};
@@ -9,6 +9,7 @@ use miden_client::{
     transaction::TransactionRequestBuilder,
     Felt, Word,
 };
+use miden_standards::testing::note::NoteBuilder;
 use std::{path::Path, sync::Arc};
 
 #[tokio::main]
@@ -61,14 +62,12 @@ async fn main() -> Result<()> {
         .context("Failed to create sender wallet account")?;
     println!("Sender account ID: {:?}", sender_account.id().to_hex());
 
-    // build increment note
-    let counter_note = create_note_from_package(
-        &mut client,
-        note_package.clone(),
-        sender_account.id(),
-        NoteCreationConfig::default(),
-    )
-    .context("Failed to create counter note from package")?;
+    // Build the increment note directly from the compiled package.
+    let counter_note = NoteBuilder::new(sender_account.id(), client.rng())
+        .package((*note_package).clone())
+        .tag(0)
+        .build()
+        .context("Failed to create counter note from package")?;
     println!("Counter note hash: {:?}", counter_note.id().to_hex());
 
     // build and submit transaction to publish note

--- a/integration/src/helpers.rs
+++ b/integration/src/helpers.rs
@@ -17,10 +17,9 @@ use miden_client::{
     note::{Note, NoteInputs, NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType},
     rpc::{Endpoint, GrpcClient},
     utils::Deserializable,
-    Client, Word,
+    Client, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_core::Felt;
 use miden_mast_package::{Package, SectionId};
 use rand::RngCore;
 

--- a/integration/src/helpers.rs
+++ b/integration/src/helpers.rs
@@ -1,20 +1,20 @@
 //! Common helper functions for scripts and tests
 
-use std::{borrow::Borrow, collections::BTreeSet, path::Path, sync::Arc};
+use std::{borrow::Borrow, path::Path, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use cargo_miden::{run, OutputType};
 use miden_client::{
     account::{
-        component::{AccountComponentMetadata, AuthFalcon512Rpo, BasicWallet, NoAuth},
+        component::{AccountComponentMetadata, BasicWallet, NoAuth},
         Account, AccountBuilder, AccountComponent, AccountId, AccountStorageMode, AccountType,
         StorageSlot,
     },
-    auth::{AuthSecretKey, PublicKeyCommitment},
+    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
-    crypto::{rpo_falcon512::SecretKey, FeltRng},
-    keystore::FilesystemKeyStore,
-    note::{Note, NoteInputs, NoteMetadata, NoteRecipient, NoteScript, NoteTag, NoteType},
+    crypto::FeltRng,
+    keystore::{FilesystemKeyStore, Keystore},
+    note::{Note, NoteMetadata, NoteRecipient, NoteScript, NoteStorage, NoteTag, NoteType},
     rpc::{Endpoint, GrpcClient},
     utils::Deserializable,
     Client, Felt, Word,
@@ -25,7 +25,9 @@ use rand::RngCore;
 
 /// Test setup configuration containing initialized client and keystore
 pub struct ClientSetup {
+    /// The configured Miden client instance.
     pub client: Client<FilesystemKeyStore>,
+    /// The filesystem-backed keystore used by the client.
     pub keystore: Arc<FilesystemKeyStore>,
 }
 
@@ -111,10 +113,12 @@ pub fn build_project_in_dir(dir: &Path, release: bool) -> Result<Package> {
 /// Configuration for creating an account with a custom component
 #[derive(Clone)]
 pub struct AccountCreationConfig {
+    /// The account type to create.
     pub account_type: AccountType,
+    /// The account storage visibility mode.
     pub storage_mode: AccountStorageMode,
+    /// Initial storage slots to seed into the component.
     pub storage_slots: Vec<StorageSlot>,
-    pub supported_types: Option<Vec<AccountType>>,
 }
 
 impl Default for AccountCreationConfig {
@@ -123,7 +127,6 @@ impl Default for AccountCreationConfig {
             account_type: AccountType::RegularAccountImmutableCode,
             storage_mode: AccountStorageMode::Public,
             storage_slots: vec![],
-            supported_types: None,
         }
     }
 }
@@ -161,18 +164,10 @@ pub fn account_component_from_package(
             let component = AccountComponent::new(
                 package.unwrap_library().as_ref().clone(),
                 config.storage_slots.clone(),
+                metadata,
             )
-            .context("Failed to create account component")?
-            .with_metadata(metadata);
-
-            // Use supported types from config if provided, otherwise default to RegularAccountImmutableCode
-            let supported_types = if let Some(types) = &config.supported_types {
-                BTreeSet::from_iter(types.clone())
-            } else {
-                BTreeSet::from_iter([AccountType::RegularAccountImmutableCode])
-            };
-
-            component.with_supported_types(supported_types)
+            .context("Failed to create account component")?;
+            component
         }
     };
 
@@ -220,6 +215,14 @@ pub async fn create_account_from_package(
     Ok(account)
 }
 
+/// Creates an existing account instance from a compiled package for testing.
+///
+/// # Arguments
+/// * `package` - The compiled package containing the account component
+/// * `config` - Configuration for account creation
+///
+/// # Errors
+/// Returns an error if the account component or account cannot be created.
 pub async fn create_testing_account_from_package(
     package: Arc<Package>,
     config: AccountCreationConfig,
@@ -240,10 +243,14 @@ pub async fn create_testing_account_from_package(
 
 /// Configuration for creating a note
 pub struct NoteCreationConfig {
+    /// The note visibility type.
     pub note_type: NoteType,
+    /// The note tag to attach to the metadata.
     pub tag: NoteTag,
+    /// Assets to include in the note.
     pub assets: miden_client::note::NoteAssets,
-    pub inputs: Vec<Felt>,
+    /// Storage items passed to the note recipient.
+    pub storage: Vec<Felt>,
 }
 
 impl Default for NoteCreationConfig {
@@ -253,7 +260,7 @@ impl Default for NoteCreationConfig {
             // Note: This should never fail for valid inputs (0, 0)
             tag: NoteTag::new(0),
             assets: Default::default(),
-            inputs: Default::default(),
+            storage: Default::default(),
         }
     }
 }
@@ -284,14 +291,23 @@ pub fn create_note_from_package(
     );
 
     let serial_num = client.rng().draw_word();
-    let note_inputs = NoteInputs::new(config.inputs).context("Failed to create note inputs")?;
-    let recipient = NoteRecipient::new(serial_num, note_script, note_inputs);
+    let note_storage = NoteStorage::new(config.storage).context("Failed to create note storage")?;
+    let recipient = NoteRecipient::new(serial_num, note_script, note_storage);
 
-    let metadata = NoteMetadata::new(sender_id, config.note_type, config.tag);
+    let metadata = NoteMetadata::new(sender_id, config.note_type).with_tag(config.tag);
 
     Ok(Note::new(config.assets, metadata, recipient))
 }
 
+/// Creates a deterministic note from a compiled package for testing.
+///
+/// # Arguments
+/// * `package` - The compiled package containing the note script
+/// * `sender_id` - The ID of the account sending the note
+/// * `config` - Configuration for note creation
+///
+/// # Errors
+/// Returns an error if note creation fails.
 pub fn create_testing_note_from_package(
     package: Arc<Package>,
     sender_id: AccountId,
@@ -308,10 +324,10 @@ pub fn create_testing_note_from_package(
     let serial_num =
         Word::try_from(random_u64s).context("Failed to convert random u64s to word")?;
 
-    let note_inputs = NoteInputs::new(config.inputs).context("Failed to create note inputs")?;
-    let recipient = NoteRecipient::new(serial_num, note_script, note_inputs);
+    let note_storage = NoteStorage::new(config.storage).context("Failed to create note storage")?;
+    let recipient = NoteRecipient::new(serial_num, note_script, note_storage);
 
-    let metadata = NoteMetadata::new(sender_id, config.note_type, config.tag);
+    let metadata = NoteMetadata::new(sender_id, config.note_type).with_tag(config.tag);
 
     Ok(Note::new(config.assets, metadata, recipient))
 }
@@ -336,14 +352,15 @@ pub async fn create_basic_wallet_account(
     let mut init_seed = [0_u8; 32];
     client.rng().fill_bytes(&mut init_seed);
 
-    let key_pair = SecretKey::with_rng(client.rng());
+    let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
 
     let builder = AccountBuilder::new(init_seed)
         .account_type(config.account_type)
         .storage_mode(config.storage_mode)
-        .with_auth_component(AuthFalcon512Rpo::new(PublicKeyCommitment::from(
+        .with_auth_component(AuthSingleSig::new(
             key_pair.public_key().to_commitment(),
-        )))
+            AuthSchemeId::Falcon512Poseidon2,
+        ))
         .with_component(BasicWallet);
 
     let account = builder
@@ -356,7 +373,8 @@ pub async fn create_basic_wallet_account(
         .context("Failed to add account to client")?;
 
     keystore
-        .add_key(&AuthSecretKey::Falcon512Rpo(key_pair))
+        .add_key(&key_pair, account.id())
+        .await
         .context("Failed to add key to keystore")?;
 
     Ok(account)

--- a/integration/src/helpers.rs
+++ b/integration/src/helpers.rs
@@ -1,23 +1,24 @@
 //! Common helper functions for scripts and tests
 
-use std::{borrow::Borrow, path::Path, sync::Arc};
+use std::{path::Path, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use cargo_miden::{run, OutputType};
 use miden_client::{
     account::{
-        component::{AccountComponentMetadata, BasicWallet, NoAuth},
-        Account, AccountBuilder, AccountComponent, AccountStorageMode, AccountType, StorageSlot,
+        component::{BasicWallet, InitStorageData, NoAuth},
+        Account, AccountBuilder, AccountComponent, AccountStorageMode, AccountType,
+        StorageSlotName,
     },
     auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
     keystore::{FilesystemKeyStore, Keystore},
     rpc::{Endpoint, GrpcClient},
     utils::Deserializable,
-    Client,
+    Client, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_mast_package::{Package, SectionId};
+use miden_mast_package::Package;
 use rand::RngCore;
 
 /// Test setup configuration containing initialized client and keystore
@@ -107,15 +108,26 @@ pub fn build_project_in_dir(dir: &Path, release: bool) -> Result<Package> {
     Package::read_from_bytes(&package_bytes).context("Failed to deserialize package from bytes")
 }
 
+/// The fixed key used by the counter contract to store the counter value.
+pub const COUNTER_STORAGE_KEY: Word = Word::new([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
+
+/// Returns the storage slot name used by the counter account component.
+///
+/// # Errors
+/// Returns an error if the fixed storage slot name is invalid.
+pub fn counter_storage_slot() -> Result<StorageSlotName> {
+    StorageSlotName::new("miden_counter_account::counter_contract::count_map")
+        .context("invalid counter storage slot name")
+}
+
 /// Configuration for creating an account with a custom component
-#[derive(Clone)]
 pub struct AccountCreationConfig {
     /// The account type to create.
     pub account_type: AccountType,
     /// The account storage visibility mode.
     pub storage_mode: AccountStorageMode,
-    /// Initial storage slots to seed into the component.
-    pub storage_slots: Vec<StorageSlot>,
+    /// Initial component storage data keyed by storage slot schema.
+    pub init_storage_data: InitStorageData,
 }
 
 impl Default for AccountCreationConfig {
@@ -123,52 +135,9 @@ impl Default for AccountCreationConfig {
         Self {
             account_type: AccountType::RegularAccountImmutableCode,
             storage_mode: AccountStorageMode::Public,
-            storage_slots: vec![],
+            init_storage_data: InitStorageData::default(),
         }
     }
-}
-
-/// Creates an account component from a compiled package
-///
-/// # Arguments
-/// * `package` - The compiled package containing account component metadata
-/// * `config` - Configuration for account creation
-///
-/// # Returns
-/// An `AccountComponent` configured according to the provided config
-///
-/// # Errors
-/// Returns an error if the package doesn't contain account component metadata or deserialization fails
-pub fn account_component_from_package(
-    package: Arc<Package>,
-    config: &AccountCreationConfig,
-) -> Result<AccountComponent> {
-    // Find the account component metadata section in the package
-    let account_component_metadata = package.sections.iter().find_map(|s| {
-        if s.id == SectionId::ACCOUNT_COMPONENT_METADATA {
-            Some(s.data.borrow())
-        } else {
-            None
-        }
-    });
-
-    let account_component = match account_component_metadata {
-        None => bail!("Package missing account component metadata"),
-        Some(bytes) => {
-            let metadata = AccountComponentMetadata::read_from_bytes(bytes)
-                .context("Failed to deserialize account component metadata")?;
-
-            let component = AccountComponent::new(
-                package.mast.as_ref().clone(),
-                config.storage_slots.clone(),
-                metadata,
-            )
-            .context("Failed to create account component")?;
-            component
-        }
-    };
-
-    Ok(account_component)
 }
 
 /// Creates an account with a custom component from a compiled package
@@ -188,8 +157,9 @@ pub async fn create_account_from_package(
     package: Arc<Package>,
     config: AccountCreationConfig,
 ) -> Result<Account> {
-    let account_component = account_component_from_package(package, &config)
-        .context("Failed to create account component from package")?;
+    let account_component =
+        AccountComponent::from_package(package.as_ref(), &config.init_storage_data)
+            .context("Failed to create account component from package")?;
 
     let mut init_seed = [0_u8; 32];
     client.rng().fill_bytes(&mut init_seed);

--- a/integration/src/helpers.rs
+++ b/integration/src/helpers.rs
@@ -7,17 +7,14 @@ use cargo_miden::{run, OutputType};
 use miden_client::{
     account::{
         component::{AccountComponentMetadata, BasicWallet, NoAuth},
-        Account, AccountBuilder, AccountComponent, AccountId, AccountStorageMode, AccountType,
-        StorageSlot,
+        Account, AccountBuilder, AccountComponent, AccountStorageMode, AccountType, StorageSlot,
     },
     auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
-    crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
-    note::{Note, NoteMetadata, NoteRecipient, NoteScript, NoteStorage, NoteTag, NoteType},
     rpc::{Endpoint, GrpcClient},
     utils::Deserializable,
-    Client, Felt, Word,
+    Client,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_mast_package::{Package, SectionId};
@@ -162,7 +159,7 @@ pub fn account_component_from_package(
                 .context("Failed to deserialize account component metadata")?;
 
             let component = AccountComponent::new(
-                package.unwrap_library().as_ref().clone(),
+                package.mast.as_ref().clone(),
                 config.storage_slots.clone(),
                 metadata,
             )
@@ -213,123 +210,6 @@ pub async fn create_account_from_package(
         .context("Failed to add account to client")?;
 
     Ok(account)
-}
-
-/// Creates an existing account instance from a compiled package for testing.
-///
-/// # Arguments
-/// * `package` - The compiled package containing the account component
-/// * `config` - Configuration for account creation
-///
-/// # Errors
-/// Returns an error if the account component or account cannot be created.
-pub async fn create_testing_account_from_package(
-    package: Arc<Package>,
-    config: AccountCreationConfig,
-) -> Result<Account> {
-    let account_component = account_component_from_package(package, &config)
-        .context("Failed to create account component from package")?;
-
-    let account = AccountBuilder::new([3u8; 32])
-        .account_type(config.account_type)
-        .storage_mode(config.storage_mode)
-        .with_component(account_component)
-        .with_auth_component(NoAuth)
-        .build_existing()
-        .context("Failed to build account")?;
-
-    Ok(account)
-}
-
-/// Configuration for creating a note
-pub struct NoteCreationConfig {
-    /// The note visibility type.
-    pub note_type: NoteType,
-    /// The note tag to attach to the metadata.
-    pub tag: NoteTag,
-    /// Assets to include in the note.
-    pub assets: miden_client::note::NoteAssets,
-    /// Storage items passed to the note recipient.
-    pub storage: Vec<Felt>,
-}
-
-impl Default for NoteCreationConfig {
-    fn default() -> Self {
-        Self {
-            note_type: NoteType::Public,
-            // Note: This should never fail for valid inputs (0, 0)
-            tag: NoteTag::new(0),
-            assets: Default::default(),
-            storage: Default::default(),
-        }
-    }
-}
-
-/// Creates a note from a compiled package
-///
-/// # Arguments
-/// * `client` - The Miden client instance
-/// * `package` - The compiled package containing the note script
-/// * `sender_id` - The ID of the account sending the note
-/// * `config` - Configuration for note creation
-///
-/// # Returns
-/// The created `Note`
-///
-/// # Errors
-/// Returns an error if note creation fails
-pub fn create_note_from_package(
-    client: &mut Client<FilesystemKeyStore>,
-    package: Arc<Package>,
-    sender_id: AccountId,
-    config: NoteCreationConfig,
-) -> Result<Note> {
-    let note_program = package.unwrap_program();
-    let note_script = NoteScript::from_parts(
-        note_program.mast_forest().clone(),
-        note_program.entrypoint(),
-    );
-
-    let serial_num = client.rng().draw_word();
-    let note_storage = NoteStorage::new(config.storage).context("Failed to create note storage")?;
-    let recipient = NoteRecipient::new(serial_num, note_script, note_storage);
-
-    let metadata = NoteMetadata::new(sender_id, config.note_type).with_tag(config.tag);
-
-    Ok(Note::new(config.assets, metadata, recipient))
-}
-
-/// Creates a deterministic note from a compiled package for testing.
-///
-/// # Arguments
-/// * `package` - The compiled package containing the note script
-/// * `sender_id` - The ID of the account sending the note
-/// * `config` - Configuration for note creation
-///
-/// # Errors
-/// Returns an error if note creation fails.
-pub fn create_testing_note_from_package(
-    package: Arc<Package>,
-    sender_id: AccountId,
-    config: NoteCreationConfig,
-) -> Result<Note> {
-    let note_program = package.unwrap_program();
-    let note_script = NoteScript::from_parts(
-        note_program.mast_forest().clone(),
-        note_program.entrypoint(),
-    );
-
-    // get 4 random u64s and convert them to a word
-    let random_u64s = [0_u64; 4];
-    let serial_num =
-        Word::try_from(random_u64s).context("Failed to convert random u64s to word")?;
-
-    let note_storage = NoteStorage::new(config.storage).context("Failed to create note storage")?;
-    let recipient = NoteRecipient::new(serial_num, note_script, note_storage);
-
-    let metadata = NoteMetadata::new(sender_id, config.note_type).with_tag(config.tag);
-
-    Ok(Note::new(config.assets, metadata, recipient))
 }
 
 /// Creates a basic wallet account with authentication

--- a/integration/tests/counter_test.rs
+++ b/integration/tests/counter_test.rs
@@ -20,7 +20,7 @@ async fn counter_test() -> anyhow::Result<()> {
     // Test that after executing the increment note, the counter value is incremented by 1
     let mut builder = MockChain::builder();
 
-    // Crate note sender account
+    // Create note sender account
     let sender = builder.add_existing_wallet(Auth::BasicAuth {
         auth_scheme: AuthSchemeId::Falcon512Poseidon2,
     })?;

--- a/integration/tests/counter_test.rs
+++ b/integration/tests/counter_test.rs
@@ -1,16 +1,29 @@
-use integration::helpers::{
-    build_project_in_dir, create_testing_account_from_package, create_testing_note_from_package,
-    AccountCreationConfig, NoteCreationConfig,
-};
+use std::{path::Path, sync::Arc};
 
+use anyhow::Context;
+use integration::helpers::build_project_in_dir;
 use miden_client::{
-    account::{StorageMap, StorageMapKey, StorageSlot, StorageSlotName},
+    account::{
+        component::InitStorageData, AccountBuilder, AccountComponent, AccountStorageMode,
+        AccountType, StorageSlotName,
+    },
     auth::AuthSchemeId,
+    crypto::RandomCoin,
+    note::NoteScript,
     transaction::RawOutputNote,
     Felt, Word,
 };
-use miden_testing::{Auth, MockChain};
-use std::{path::Path, sync::Arc};
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{AccountState, Auth, MockChain};
+
+/// The fixed key used by the counter contract to store the counter value.
+const COUNTER_STORAGE_KEY: Word = Word::new([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
+
+/// Returns the storage slot name used by the counter account component.
+fn counter_storage_slot() -> anyhow::Result<StorageSlotName> {
+    StorageSlotName::new("miden_counter_account::counter_contract::count_map")
+        .context("invalid counter storage slot name")
+}
 
 #[tokio::test]
 async fn counter_test() -> anyhow::Result<()> {
@@ -32,68 +45,64 @@ async fn counter_test() -> anyhow::Result<()> {
         true,
     )?);
 
-    // Create the counter account with initial storage and no-auth auth component
-    let count_storage_key = Word::from([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(1)]);
-    let initial_count = Word::from([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(0)]);
+    // Create the counter account with its initial storage through the component schema.
+    let counter_storage_slot = counter_storage_slot()?;
+    let mut init_storage_data = InitStorageData::default();
+    init_storage_data.insert_map_entry(counter_storage_slot.clone(), COUNTER_STORAGE_KEY, 0_u64)?;
 
-    // The slot name is constructed as
-    // `miden::component::[to_underscore(Cargo.toml:package.metadata.component.package)]::[field_name]`
-    let counter_storage_slot =
-        StorageSlotName::new("miden_counter_account::counter_contract::count_map").unwrap();
-    let storage_slots = vec![StorageSlot::with_map(
-        counter_storage_slot.clone(),
-        StorageMap::with_entries([(StorageMapKey::new(count_storage_key), initial_count)]).unwrap(),
-    )];
-    let counter_cfg = AccountCreationConfig {
-        storage_slots,
-        ..Default::default()
-    };
-
-    // create testing counter account
-    let mut counter_account =
-        create_testing_account_from_package(contract_package.clone(), counter_cfg).await?;
-
-    // create testing increment note
-    let counter_note = create_testing_note_from_package(
-        note_package.clone(),
-        sender.id(),
-        NoteCreationConfig::default(),
+    let counter_component = AccountComponent::from_package(&contract_package, &init_storage_data)
+        .context("failed to build account component from counter package")?;
+    let counter_account = builder.add_account_from_builder(
+        Auth::BasicAuth {
+            auth_scheme: AuthSchemeId::Falcon512Poseidon2,
+        },
+        AccountBuilder::new([3_u8; 32])
+            .account_type(AccountType::RegularAccountImmutableCode)
+            .storage_mode(AccountStorageMode::Public)
+            .with_component(counter_component),
+        AccountState::Exists,
     )?;
 
+    let mut note_rng = RandomCoin::new(
+        NoteScript::from_package(note_package.as_ref())
+            .context("failed to build note script from package")?
+            .root(),
+    );
+    let counter_note = NoteBuilder::new(sender.id(), &mut note_rng)
+        .package((*note_package).clone())
+        .build()
+        .context("failed to build counter note from package")?;
+
     // add counter account and note to mockchain
-    builder.add_account(counter_account.clone())?;
     builder.add_output_note(RawOutputNote::Full(counter_note.clone()));
 
     // Build the mock chain
     let mut mock_chain = builder.build()?;
+
     // Build the transaction context
     let tx_context = mock_chain
-        .build_tx_context(counter_account.id(), &[counter_note.id()], &[])?
+        .build_tx_context(counter_account.clone(), &[counter_note.id()], &[])?
         .build()?;
 
     // Execute the transaction
     let executed_transaction = tx_context.execute().await?;
-
-    // Apply the account delta to the counter account
-    counter_account.apply_delta(executed_transaction.account_delta())?;
 
     // Add the executed transaction to the mockchain
     mock_chain.add_pending_executed_transaction(&executed_transaction)?;
     mock_chain.prove_next_block()?;
 
     // Get the count from the updated counter account
-    let count = counter_account
+    let count = mock_chain
+        .committed_account(counter_account.id())?
         .storage()
-        .get_map_item(&counter_storage_slot, count_storage_key)
+        .get_map_item(&counter_storage_slot, COUNTER_STORAGE_KEY)
         .expect("Failed to get counter value from storage slot");
 
-    // Assert that the count value is equal to 1 after executing the transaction
+    // Map values are returned as scalar words in `[value, 0, 0, 0]` layout.
     assert_eq!(
-        count,
-        Word::from([Felt::new(0), Felt::new(0), Felt::new(0), Felt::new(1)]),
+        count[0].as_canonical_u64(),
+        1,
         "Count value is not equal to 1"
     );
-
-    println!("Test passed!");
     Ok(())
 }

--- a/integration/tests/counter_test.rs
+++ b/integration/tests/counter_test.rs
@@ -39,7 +39,7 @@ async fn counter_test() -> anyhow::Result<()> {
     // The slot name is constructed as
     // `miden::component::[to_underscore(Cargo.toml:package.metadata.component.package)]::[field_name]`
     let counter_storage_slot =
-        StorageSlotName::new("miden::component::miden_counter_account::count_map").unwrap();
+        StorageSlotName::new("miden_counter_account::counter_contract::count_map").unwrap();
     let storage_slots = vec![StorageSlot::with_map(
         counter_storage_slot.clone(),
         StorageMap::with_entries([(StorageMapKey::new(count_storage_key), initial_count)]).unwrap(),

--- a/integration/tests/counter_test.rs
+++ b/integration/tests/counter_test.rs
@@ -1,29 +1,19 @@
 use std::{path::Path, sync::Arc};
 
 use anyhow::Context;
-use integration::helpers::build_project_in_dir;
+use integration::helpers::{build_project_in_dir, counter_storage_slot, COUNTER_STORAGE_KEY};
 use miden_client::{
     account::{
         component::InitStorageData, AccountBuilder, AccountComponent, AccountStorageMode,
-        AccountType, StorageSlotName,
+        AccountType,
     },
     auth::AuthSchemeId,
     crypto::RandomCoin,
     note::NoteScript,
     transaction::RawOutputNote,
-    Felt, Word,
 };
 use miden_standards::testing::note::NoteBuilder;
 use miden_testing::{AccountState, Auth, MockChain};
-
-/// The fixed key used by the counter contract to store the counter value.
-const COUNTER_STORAGE_KEY: Word = Word::new([Felt::ZERO, Felt::ZERO, Felt::ZERO, Felt::ONE]);
-
-/// Returns the storage slot name used by the counter account component.
-fn counter_storage_slot() -> anyhow::Result<StorageSlotName> {
-    StorageSlotName::new("miden_counter_account::counter_contract::count_map")
-        .context("invalid counter storage slot name")
-}
 
 #[tokio::test]
 async fn counter_test() -> anyhow::Result<()> {

--- a/integration/tests/counter_test.rs
+++ b/integration/tests/counter_test.rs
@@ -4,8 +4,9 @@ use integration::helpers::{
 };
 
 use miden_client::{
-    account::{StorageMap, StorageSlot, StorageSlotName},
-    transaction::OutputNote,
+    account::{StorageMap, StorageMapKey, StorageSlot, StorageSlotName},
+    auth::AuthSchemeId,
+    transaction::RawOutputNote,
     Felt, Word,
 };
 use miden_testing::{Auth, MockChain};
@@ -17,7 +18,9 @@ async fn counter_test() -> anyhow::Result<()> {
     let mut builder = MockChain::builder();
 
     // Crate note sender account
-    let sender = builder.add_existing_wallet(Auth::BasicAuth)?;
+    let sender = builder.add_existing_wallet(Auth::BasicAuth {
+        auth_scheme: AuthSchemeId::Falcon512Poseidon2,
+    })?;
 
     // Build contracts
     let contract_package = Arc::new(build_project_in_dir(
@@ -39,7 +42,7 @@ async fn counter_test() -> anyhow::Result<()> {
         StorageSlotName::new("miden::component::miden_counter_account::count_map").unwrap();
     let storage_slots = vec![StorageSlot::with_map(
         counter_storage_slot.clone(),
-        StorageMap::with_entries([(count_storage_key, initial_count)]).unwrap(),
+        StorageMap::with_entries([(StorageMapKey::new(count_storage_key), initial_count)]).unwrap(),
     )];
     let counter_cfg = AccountCreationConfig {
         storage_slots,
@@ -59,7 +62,7 @@ async fn counter_test() -> anyhow::Result<()> {
 
     // add counter account and note to mockchain
     builder.add_account(counter_account.clone())?;
-    builder.add_output_note(OutputNote::Full(counter_note.clone()));
+    builder.add_output_note(RawOutputNote::Full(counter_note.clone()));
 
     // Build the mock chain
     let mut mock_chain = builder.build()?;


### PR DESCRIPTION

TODO:
- [x] switch to the released `cargo-miden` and move git tag;
- [x] migrate agent skills;
- [x] switch to the published `miden-client` v0.14;
- [x] move the v0.10 git tag;