### PR TITLE
fix(hooks): use jq to safely escape build error output in JSON

### DIFF
--- a/.claude/hooks/build-contracts.sh
+++ b/.claude/hooks/build-contracts.sh
@@ -37,6 +37,7 @@ if [[ $BUILD_EXIT -eq 0 ]]; then
   exit 0
 else
   TAIL_OUTPUT=$(echo "$BUILD_OUTPUT" | tail -20)
-  echo "{\"hookSpecificOutput\": {\"additionalContext\": \"Contract build FAILED. Fix compilation errors before continuing.\n$TAIL_OUTPUT\"}}"
+  jq -n --arg ctx "Contract build FAILED. Fix compilation errors before continuing."$'\n'"$TAIL_OUTPUT" \
+    '{"hookSpecificOutput": {"additionalContext": $ctx}}'
   exit 2
 fi


### PR DESCRIPTION
When a contract build fails, Rust compiler errors (which contain double quotes, backslashes, and newlines) were embedded directly into a manually constructed JSON string on line 40 of build-contracts.sh. This produces malformed JSON that the Claude Code hook protocol cannot parse, so error context is silently lost. Fixed by using jq --arg to inject the string, which handles all JSON escaping automatically. jq is already a dependency used earlier in the script.