### PR TITLE
chore(ci): replace deprecated actions with current equivalents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Rust
       run: |
         rustup update --no-self-update
         rustc --version
     - name: Install Miden cargo extension
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: cargo-miden
+      run: cargo install cargo-miden
     - name: Run integration tests
       working-directory: integration
       run: cargo test


### PR DESCRIPTION
 Replace two deprecated actions in `.github/workflows/ci.yml`

  - **`actions/checkout@v2` → v4**: v2 is deprecated; v4 is the current supported
   version
  - **`actions-rs/cargo@v1` → direct `run` step**: the `actions-rs` org is
  archived and unmaintained; `cargo install cargo-miden` is simpler and removes
  the third-party dependency

  ---