### PR TITLE
chore(skills): sync skills to miden v0.15

### DIFF
--- a/.claude/skills/local-node-validation/SKILL.md
+++ b/.claude/skills/local-node-validation/SKILL.md
@@ -11,46 +11,72 @@ Validates that contracts working in MockChain also work against a real Miden nod
 
 MockChain simplifies execution in ways that hide real-world failures:
 
-1. **No automatic block production** -- MockChain requires explicit `prove_next_block()`. A live node produces blocks on its own schedule.
-2. **No network transport** -- MockChain does not simulate the network transaction builder that handles network notes.
+1. **No automatic block production** -- MockChain requires explicit `prove_next_block()`. A live node produces blocks on the sequencer's configured cadence.
+2. **No network transport** -- MockChain does not simulate the network transaction builder (ntx-builder) that handles network notes.
 3. **No RPC latency or timeouts** -- MockChain executes locally and instantly. Live nodes have gRPC round-trips with configurable timeouts.
-4. **No version/genesis validation** -- MockChain skips the `Accept` header version check that live nodes enforce.
+4. **No version negotiation** -- MockChain skips the protocol-version check that a live node negotiates at connect (a mismatched node is rejected).
 5. **Account update block numbers not tracked** -- MockChain returns chain tip instead of actual update block number.
 6. **No mempool or batching** -- MockChain does not simulate transaction queuing, batch formation, or block inclusion delays.
-7. **Genesis hash is cached in the client store** -- after the first sync, the client persists the network's genesis commitment in its SQLite store (default path `store.sqlite3` per `integration/src/helpers.rs`; `local-store.sqlite3` for the local-validation variant introduced in Step 2) and ships it on every Accept header. Switching networks (local node to testnet, or vice versa) without wiping the active store fails with `accept header validation failed`.
-8. **`NoteTag(0)` notes are not delivered by default subscriptions** -- live nodes filter `SyncNotes` responses by the tag list each client has subscribed to. `NoteTag::new(0)` has all-zero routing bits, so the default account-derived subscription that `add_account` registers (`NoteTagRecord::with_account_source(NoteTag::with_account_target(id), id)`) does not match it. Such notes still exist on-chain and remain queryable, but a client only receives them during sync if it explicitly tracks tag 0 via `Client::add_note_tag(...)`. MockChain bypasses sync filtering and surfaces these notes anyway, hiding the gap until live validation. Prefer `NoteTag::with_account_target(account_id)`, a use-case tag constructor, or an explicit `add_note_tag` subscription when notes must reach the recipient via sync.
+7. **`NoteTag(0)` notes are not delivered by default subscriptions** -- live nodes filter `SyncNotes` responses by the tag list each client has subscribed to. `NoteTag::new(0)` has all-zero routing bits, so the default account-derived subscription that `add_account` registers (`NoteTagRecord::with_account_source(NoteTag::with_account_target(id), id)`) does not match it. Such notes still exist on-chain and remain queryable, but a client only receives them during sync if it explicitly tracks tag 0 via `Client::add_note_tag(...)`. MockChain bypasses sync filtering and surfaces these notes anyway, hiding the gap until live validation. Prefer `NoteTag::with_account_target(account_id)`, a use-case tag constructor, or an explicit `add_note_tag` subscription when notes must reach the recipient via sync.
 
 ## Prerequisites
 
 - [ ] MockChain integration tests pass: `cargo test -p integration --release`
-- [ ] `miden-node` installed and version-matched with the client. Check the `miden-client` version in `integration/Cargo.toml`; the node binary must be on the same minor release. `cargo install miden-node --locked` may pin an older published crate; if so, install from source: `cargo install miden-node --locked --git https://github.com/0xMiden/miden-node --tag v<version>`. `midenup` manages matched toolchains.
-- [ ] Working integration binary exists in `integration/src/bin/`
+- [ ] A Miden node available locally. The node is **not** a single binary -- it is composed of standalone executables (validator, sequencer, ntx-builder, transaction prover). The client's own test infra installs the full set: `miden-validator`, `miden-node`, `miden-ntx-builder`, `miden-remote-prover` (see `scripts/start-test-node.sh` in the `miden-client` repo). Install them from the node source pinned in your client's `Cargo.lock`, or follow the 0xMiden/node quickstart for the authoritative install flow. Match the node to the `miden-client` version in `integration/Cargo.toml` (`miden-client = "0.15"`); `midenup` manages matched toolchains.
+- [ ] Working integration binary exists in `integration/src/bin/` (the testnet binary `increment_count.rs` is the starting template for the localhost variant)
+
+> The local-node launch CLI lives in the 0xMiden/node repo, not in `miden-client`. The commands below are the topology the client's `scripts/start-test-node.sh` drives; confirm exact flags against your installed node's `--help` for the version you run.
 
 ## Step 1: Clean State and Start Local Node
 
-**Every node session must start from clean state.** Stale store files and keystore directories cause conflicts, deserialization errors, and misleading test results. Always wipe before starting.
+**Every node session must start from clean state.** Stale store files and keystore directories cause conflicts, deserialization errors, and misleading test results. Always wipe before starting. (Node and client artifacts also do not round-trip across protocol versions, so a fresh store is required after any version change.)
+
+The simplest path is the client's bundled helper script, which installs the node binaries (pinned to your `Cargo.lock`), generates genesis, bootstraps each component, and starts the split topology for you:
 
 ```bash
-# 1. Wipe all state from previous runs
-rm -rf local-node-data/ local-keystore/ local-store.sqlite3
+# From a checkout of the miden-client repo pinned to your client version:
+./scripts/start-test-node.sh            # foreground, streams logs; Ctrl+C stops
+# or
+./scripts/start-test-node.sh --background   # returns once RPC is ready (used by CI)
+```
 
-# 2. Bootstrap fresh node
-mkdir -p local-node-data
-miden-node bundled bootstrap \
-  --data-directory local-node-data \
-  --accounts-directory .
+This brings up the four-component topology and exposes the RPC on `127.0.0.1:57291` (the client default, `MIDEN_NODE_PORT`).
 
-# 3. Start node (keep running in separate terminal)
-miden-node bundled start \
-  --data-directory local-node-data \
-  --rpc.url http://0.0.0.0:57291
+If you run the node binaries directly instead of via the script, the shape is below. Treat it as a reference skeleton, not a copy-paste recipe: it omits details the script handles for you (it does not show generating the genesis config the validator bootstraps from, and it leaves out the shared network-tx auth header that the sequencer and ntx-builder must agree on or the sequencer rejects the ntx-builder's transactions). Verify every subcommand and flag against `--help` for your node version, or just use the script.
+
+```bash
+# 1. Bootstrap each component from a generated genesis block
+#    (the genesis config/block must be produced first; the helper script
+#     builds it from the client repo before this step)
+miden-validator   bootstrap --data-directory <data>/validator \
+  --genesis-block-directory <data>/genesis --accounts-directory <data>/accounts \
+  --genesis-config-file <data>/genesis-config/genesis.toml
+miden-node        bootstrap --data-directory <data>/node        --file <data>/genesis/genesis.dat
+miden-ntx-builder bootstrap --data-directory <data>/ntx-builder --file <data>/genesis/genesis.dat
+
+# 2. Start the components (validator, then sequencer with the RPC, prover, ntx-builder).
+#    The sequencer and ntx-builder additionally need a matching network-tx auth header
+#    (--rpc.network-tx-auth-header-value / --rpc.auth-header-value in the script); see the script.
+miden-validator start --listen 127.0.0.1:50101 --data-directory <data>/validator
+miden-node sequencer --rpc.listen 127.0.0.1:57291 --data-directory <data>/node \
+  --validator.url http://127.0.0.1:50101 --ntx-builder.url http://127.0.0.1:50301 \
+  --block.interval 3s --batch.interval 1s
+miden-remote-prover --kind=transaction --port=50051
+miden-ntx-builder start --listen 127.0.0.1:50301 --rpc.url http://127.0.0.1:57291 \
+  --tx-prover.url http://127.0.0.1:50051 --data-directory <data>/ntx-builder
 ```
 
 **This clean-start sequence is mandatory every time.** Do not attempt to reuse state from a previous session.
 
 ## Step 2: Adapt helpers.rs for Localhost
 
-In `integration/src/helpers.rs`, add a `setup_local_client()` alongside the existing `setup_client()`:
+In `integration/src/helpers.rs`, add a `setup_local_client()` alongside the existing `setup_client()`.
+
+`.sqlite_store(..)` is **not** an inherent `ClientBuilder` method -- it comes from an extension trait in the `miden-client-sqlite-store` crate. It must be in scope or the call fails to compile (method not found). `helpers.rs` already imports it at the top of the file:
+
+```rust
+use miden_client_sqlite_store::ClientBuilderSqliteExt; // required for .sqlite_store(..)
+```
 
 ```rust
 pub async fn setup_local_client() -> Result<ClientSetup> {
@@ -87,7 +113,7 @@ The binary must:
 1. Call `setup_local_client()` instead of `setup_client()`
 2. Sync state: `client.sync_state().await?`
 3. Build contracts (same as existing binary)
-4. Create accounts, create notes, submit transactions
+4. Create accounts, create notes, submit transactions via `client.submit_new_transaction(...)`
 5. Sync again after each transaction submission
 6. Wait for transaction inclusion (poll `sync_state` until account state updates)
 7. Verify final state matches MockChain test expectations
@@ -120,11 +146,14 @@ cargo run --bin validate_local --release
 
 ## Step 5: Inspect Node Logs
 
-Run the node with verbose logging:
+Run the node with verbose logging. The helper script honors `RUST_LOG` and writes a per-component log file per service; if you launch the binaries directly, set it on the process you want to inspect (the sequencer carries the RPC):
+
 ```bash
-RUST_LOG=info miden-node bundled start \
-  --data-directory local-node-data \
-  --rpc.url http://0.0.0.0:57291
+RUST_LOG=info ./scripts/start-test-node.sh
+# or, running the sequencer directly:
+RUST_LOG=info miden-node sequencer --rpc.listen 127.0.0.1:57291 --data-directory <data>/node \
+  --validator.url http://127.0.0.1:50101 --ntx-builder.url http://127.0.0.1:50301 \
+  --block.interval 3s --batch.interval 1s
 ```
 
 Look for:
@@ -136,11 +165,15 @@ Look for:
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `Unavailable` RPC error | Node not running or wrong port | Start node, verify port 57291 |
-| `accept header validation failed` after switching networks | Client store cached the genesis commitment from a different network | Delete the active client store (`store.sqlite3` by default; `local-store.sqlite3` for local validation) and re-sync |
-| Version mismatch error | Node binary lags client crate (`cargo install miden-node` may pin an older published crate) | Reinstall to match `miden-client` from `integration/Cargo.toml`: `cargo install miden-node --locked --git https://github.com/0xMiden/miden-node --tag v<version>`, or use `midenup` |
+| `Unavailable` RPC error | Node not running or wrong port | Start node, verify the sequencer's RPC is listening on 57291 |
+| Version mismatch error | Node and client crate versions differ | Run a node built from the node source pinned in your client's `Cargo.lock` (match `miden-client = "0.15"` in `integration/Cargo.toml`); the protocol version is negotiated at connect and a mismatch is rejected |
 | Vite or proxy returns 404 on RPC calls from frontend | Proxy targets the wrong path prefix | gRPC paths are `/rpc.Api/<method>` (e.g. `/rpc.Api/Status`, `/rpc.Api/SyncNotes`, `/rpc.Api/GetAccount`); forward the `/rpc.Api` prefix in the proxy config |
 | Transaction rejected | Invalid proof or state | Check contract code, reset node data, try again |
 | Account not found after `add_account()` | `add_account()` is local-only; it does not register the account on-chain | Submit a transaction involving the account to deploy it on-chain, then `sync_state()` |
-| Store errors or deserialization failures | Stale state from a previous session, or cached genesis from a different network | Wipe everything: `rm -rf local-node-data/ local-keystore/ local-store.sqlite3` and re-bootstrap |
-| Block not produced | Node produces blocks when transactions arrive | Submit a transaction; check `--block-producer.block-interval` setting |
+| Store errors or deserialization failures | Stale state from a previous session, or artifacts from an earlier protocol version, which do not round-trip | Wipe the node data, keystore, and client store (`rm -rf local-node-data/ local-keystore/ local-store.sqlite3`), then re-bootstrap from a fresh genesis |
+| `.sqlite_store(..)` does not compile | Extension trait not in scope | `use miden_client_sqlite_store::ClientBuilderSqliteExt;` |
+| Block not produced | Node produces blocks on the sequencer's configured cadence | Submit a transaction; check the sequencer's `--block.interval` (and `--batch.interval`) settings, or consult `miden-node sequencer --help` |
+
+## Cross-References
+
+- `miden-client-cli`: for driving a running node from the shell (create accounts, mint, send, consume notes) instead of a Rust binary; pair it with this skill's Step 1 node bootstrap for localhost workflows.

--- a/.claude/skills/miden-concepts/SKILL.md
+++ b/.claude/skills/miden-concepts/SKILL.md
@@ -40,7 +40,7 @@ Accounts are composed from **components** — reusable Rust modules annotated wi
 ### Notes
 Notes are **UTXO-like messages** for asynchronous inter-account communication. A note contains:
 - **Script** — Logic that executes when the note is consumed
-- **Inputs** — Data passed to the script (Vec<Felt>)
+- **Storage** — Data accessible to the script during execution (`NoteStorage`, backed by `Vec<Felt>`)
 - **Assets** — Fungible/non-fungible tokens attached to the note
 - **Metadata** — Sender, tag, note type (public/private)
 
@@ -67,7 +67,8 @@ A transaction is a **single-account state transition** with 4 phases:
 ### Felt and Word
 - **Felt**: Field element in the Goldilocks prime field (p = 2^64 - 2^32 + 1). The fundamental data unit.
 - **Word**: Array of 4 Felts (32 bytes). Used for cryptographic hashes, storage keys, account IDs.
-- **Current constructors**: `Felt::new`, `Felt::from_u8` / `from_u16` / `from_u32`, `Felt::from_canonical_checked`, `Word::new`, `Word::from([u32; 4])`, `Word::from([Felt; 4])`, `Word::try_from([u64; 4])`
+- **Felt constructors** (Rust `miden_field::Felt` — the same type used host-side in clients/tests *and* guest-side inside `#[component]`/`#[note]` contract code, which re-exports it): `Felt::new(u64)` is **fallible** — it returns `Result<Felt, FeltFromIntError>` and rejects out-of-range values (delegates to `from_canonical_checked`), so callers must `?`/match it (guest code typically `Felt::new(0).unwrap()`). `Felt::new_unchecked(u64)` is the raw, non-reducing constructor (any `u64`, no validation). Always-succeed constructors (return a bare `Felt`): `Felt::from_u8` / `from_u16` / `from_u32`. Non-panicking but fallible: `Felt::from_canonical_checked(u64) -> Option<Felt>` (returns `None` when out of range).
+- **Word constructors**: `Word::new`, `Word::from([u32; 4])`, `Word::from([Felt; 4])`, `Word::try_from([u64; 4])`
 - **Current accessors**: `felt.as_canonical_u64()`, `word.as_elements()`, `word.into_elements()`, `word.as_bytes()`, `word.to_hex()`
 
 **WARNING**: Felt arithmetic is **modular**. Subtraction wraps around the prime. Always validate with `.as_canonical_u64()` before subtracting. See the rust-sdk-pitfalls skill for details.
@@ -79,6 +80,19 @@ A transaction is a **single-account state transition** with 4 phases:
 | **P2ID** | Send assets to a specific account | Note script checks consumer's ID matches target |
 | **P2IDE** | P2ID with expiration | Adds block-height timelock; sender can reclaim after expiry |
 | **SWAP** | Atomic asset exchange | Note offers asset A, requests asset B; consumer provides B |
+
+## Standard Components (miden-standards)
+
+| Component | Purpose |
+|-----------|---------|
+| `BasicWallet` | Standard wallet: `receive_asset()`, `move_asset_to_note()` |
+| `FungibleFaucet` | Mint/burn fungible tokens; built via `FungibleFaucet::builder()` |
+| `NoAuth` | No authentication (for testing) |
+| `AuthSingleSig` | Production signature authentication — unified auth component covering both Falcon-512 and ECDSA-K256 key types |
+
+**Auth**: `AuthSingleSig` is a single auth component that dispatches on the key type, so one component handles both Falcon-512 and ECDSA-K256 keys. The Falcon-512 scheme uses Poseidon2 as its hash function and is named `Falcon512Poseidon2`.
+
+**Fungible faucet**: `FungibleFaucet` is the fungible-faucet component, constructed with the `bon`-generated `FungibleFaucet::builder()` (required setters `.name(TokenName::new(..)?)`, `.symbol(TokenSymbol::new(..)?)`, `.decimals(n)`, `.max_supply(AssetAmount)`, then `.build()?`).
 
 ## Development Model
 

--- a/.claude/skills/rust-sdk-patterns/SKILL.md
+++ b/.claude/skills/rust-sdk-patterns/SKILL.md
@@ -1,42 +1,129 @@
 ---
 name: rust-sdk-patterns
-description: Complete guide to writing Miden smart contracts with the Rust SDK. Covers #[component], #[note], #[tx_script] macros, storage patterns, native functions, asset handling, cross-component calls, P2ID note creation, and asset receiving via component methods. Use when writing, editing, or reviewing Miden Rust contract code.
+description: Complete guide to writing Miden smart contracts with the Rust SDK. Covers the three-part #[component_storage]/#[component] account-component pattern, #[note]/#[note_script] notes, #[tx_script] scripts, the #[account(...)] wrapper, storage patterns, native functions, asset handling, cross-component calls, P2ID note creation, and asset receiving via component methods. Use when writing, editing, or reviewing Miden Rust contract code.
 ---
 
 # Miden Rust SDK Patterns
 
 ## Three Contract Types
 
-### Account Component (`#[component]`)
+### Account Component (three-part pattern)
 Defines reusable logic and storage for accounts. Accounts are composed of one or more components.
 
-See [counter-account/src/lib.rs](../../../contracts/counter-account/src/lib.rs) for a working example demonstrating `#[component]`, typed `StorageMap<Word, Felt>`, `get()`/`set()`, and felt arithmetic.
+An account component is written as **three parts** — the storage struct is annotated `#[component_storage]`, and `#[component]` applies to the API trait and the impl block:
 
-**Cargo.toml for accounts:** See [counter-account/Cargo.toml](../../../contracts/counter-account/Cargo.toml) for the required `crate-type`, `miden` dependency, `component` metadata, and `project-kind`.
+1. `#[component_storage]` on the **storage struct** — declares typed `#[storage(...)]` fields and derives slot names.
+2. `#[component]` on a **trait** — the component's exported API (this is the source of the generated WIT interface).
+3. `#[component]` on the **`impl Trait for Storage`** block — the behavior, wired to the guest bindings.
 
-### Note Script (`#[note]`)
+```rust
+#![no_std]
+#![feature(alloc_error_handler)]
+use miden::{component, component_storage, felt, Felt, StorageMap, Word};
+
+#[component_storage]
+struct CounterContractStorage {
+    #[storage(description = "counter contract storage map")]
+    count_map: StorageMap<Word, Felt>,
+}
+
+#[component]
+trait CounterContract {
+    fn get_count(&self) -> Felt;
+    fn increment_count(&mut self) -> Felt;
+}
+
+#[component]
+impl CounterContract for CounterContractStorage {
+    fn get_count(&self) -> Felt {
+        let key = Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]);
+        self.count_map.get(key)
+    }
+
+    fn increment_count(&mut self) -> Felt {
+        let key = Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]);
+        let current_value: Felt = self.count_map.get(key);
+        let new_value = current_value + felt!(1);
+        self.count_map.set(key, new_value);
+        new_value
+    }
+}
+```
+
+Only the trait's methods are exported to WIT. Inherent (`impl CounterContractStorage`) methods stay private to the contract — use them for helpers like key derivation.
+
+See [counter-account/src/lib.rs](../../../contracts/counter-account/src/lib.rs) for the complete working example demonstrating the three-part pattern, typed `StorageMap<Word, Felt>`, `get()`/`set()`, and felt arithmetic.
+
+**Project metadata for accounts:** See [counter-account/miden-project.toml](../../../contracts/counter-account/miden-project.toml) for `[lib] kind = "account-component"`, the `namespace` (`miden:counter-account/counter-contract@0.1.0`), and `supported-types` under `[package.metadata.miden]`. The `Cargo.toml` (see [counter-account/Cargo.toml](../../../contracts/counter-account/Cargo.toml)) only needs `crate-type = ["cdylib"]` and the `miden` dependency.
+
+### Note Script (`#[note]` / `#[note_script]`)
 Executes when a note is consumed by an account. Can call component methods on the consuming account.
 
-See [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) for a working example demonstrating `#[note]`, `#[note_script]`, and cross-component calls.
-
-**Cargo.toml for notes:** See [increment-note/Cargo.toml](../../../contracts/increment-note/Cargo.toml) for the required `miden` deps, cross-component dependencies, wit deps, and `project-kind = "note-script"`.
-
-### Transaction Script (`#[tx_script]`)
-One-off logic executed in the context of an account. Used for initialization, admin operations, etc.
+A note is two parts: a `#[note]` struct (the note inputs type) and a `#[note]` `impl` block containing exactly one `#[note_script]` entrypoint. The entrypoint takes `self` **by value**, exactly one `Word` argument, and optionally a single reference to an `#[account(...)]` wrapper (`&MyAccount` or `&mut MyAccount`). The consuming account is declared separately with `#[account(...)]`.
 
 ```rust
 #![no_std]
 #![feature(alloc_error_handler)]
 use miden::*;
-use crate::bindings::Account;
 
-#[tx_script]
-fn run(_arg: Word, account: &mut Account) {
-    account.initialize();
+// The native (active) account this note runs against: exposes the
+// counter-account `CounterContract` component's methods on the wrapper.
+#[account(counter_account::CounterContract)]
+pub struct Wallet;
+
+#[note]
+struct IncrementNote;
+
+#[note]
+impl IncrementNote {
+    #[note_script]
+    fn run(self, _arg: Word, account: &mut Wallet) {
+        let initial_value = account.get_count();
+        account.increment_count();
+        let expected_value = initial_value + Felt::from_u32(1);
+        let final_value = account.get_count();
+        assert_eq(final_value, expected_value);
+    }
 }
 ```
 
-**Cargo.toml:** Same as account but with `project-kind = "tx-script"`.
+See [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) for the working example demonstrating `#[note]`, `#[note_script]`, the `#[account(...)]` wrapper, and a cross-component call.
+
+**Project metadata for notes:** See [increment-note/miden-project.toml](../../../contracts/increment-note/miden-project.toml) for `[lib] kind = "note"`, the `namespace` (`miden:increment-note/miden-increment-note@0.1.0`), the path dependency on the called component (`counter-account = { path = "../counter-account" }`), and the cross-component `[package.metadata.miden.dependencies]` WIT entry.
+
+### Transaction Script (`#[tx_script]`)
+One-off logic executed in the context of an account. Used for initialization, admin operations, etc.
+
+`#[tx_script]` annotates a free `fn run`. Its signature is `fn run(arg: Word)` or `fn run(arg: Word, account: &mut MyAccount)` where `MyAccount` is an `#[account(...)]` wrapper. You declare the account wrapper yourself with `#[account(...)]`, and the macro instantiates it as the active account.
+
+```rust
+#![no_std]
+#![feature(alloc_error_handler)]
+use miden::*;
+
+// The account this tx-script runs against: the counter-account `CounterContract` component.
+#[account(counter_account::CounterContract)]
+pub struct Wallet;
+
+#[tx_script]
+fn run(_arg: Word, account: &mut Wallet) {
+    account.increment_count();
+}
+```
+
+**Project metadata for tx scripts:** Like a note, but `[lib] kind = "tx-script"` and `namespace = "miden:base/transaction-script@1.0.0"`.
+
+## Storage Slot Naming
+
+Storage slot names are part of the on-chain storage ABI and are derived as:
+
+```
+<package_name_snake>::<interface_segment_snake>::<field_name>
+```
+
+The **middle segment is the interface segment of the `[lib].namespace`** in `miden-project.toml` (the part between the last `/` and `@`), snake-cased — **not** the snake-cased struct name. This deliberately decouples slot names from private Rust renames.
+
+Example: package `counter-account` + `namespace = "miden:counter-account/counter-contract@0.1.0"` + field `count_map` derives slot `counter_account::counter_contract::count_map` (see [integration/src/helpers.rs](../../../integration/src/helpers.rs) `counter_storage_slot()` and [counter_test.rs](../../../integration/tests/counter_test.rs)). The version suffix (`@0.1.0`) is ignored so the slot name stays stable. Slots are derived from the slot name; there is no `slot(...)` attribute. See the rust-sdk-pitfalls skill (P5) for more on slot naming.
 
 ## Storage Types
 
@@ -49,22 +136,20 @@ fn run(_arg: Word, account: &mut Account) {
 
 | Module | Key Functions | Purpose |
 |--------|--------------|---------|
-| `native_account::` | `add_asset(Asset)`, `remove_asset(Asset)`, `incr_nonce()` | Modify account vault/nonce |
-| `active_account::` | `get_id() -> AccountId`, `get_balance(AccountId) -> Felt` | Query current account |
-| `active_note::` | `get_assets() -> Vec<Asset>`, `get_sender() -> AccountId` | Query note being consumed (typed note storage arrives as `self` in the `#[note_script]` method; see "Cross-Component Note Pattern" below) |
+| `native_account::` | `add_asset(Asset) -> Word`, `remove_asset(Asset) -> Word`, `incr_nonce() -> Felt`, `get_id() -> AccountId` | Modify current account vault/nonce |
+| `active_account::` | `get_id() -> AccountId`, `get_balance(Word) -> Felt` | Query current account (`get_balance` takes the asset key word, not an AccountId) |
+| `active_note::` | `get_storage() -> Vec<Felt>`, `get_assets() -> Vec<Asset>`, `get_sender() -> AccountId` | Query note being consumed |
 | `note::` | `build_recipient(Word, Word, Vec<Felt>) -> Recipient` | Build note recipients from serial number, script root, and note storage |
 | `output_note::` | `create(Tag, NoteType, Recipient) -> NoteIdx`, `add_asset(Asset, NoteIdx)` | Create output notes |
 | `faucet::` | `create_fungible_asset(Felt) -> Asset`, `mint(Asset)`, `burn(Asset)` | Asset minting |
 | `tx::` | `get_block_number() -> Felt`, `get_block_timestamp() -> Felt` | Transaction context |
-| Intrinsics | `assert(bool)`, `assertz(Felt)`, `assert_eq(Felt, Felt)` | Validation |
+| Intrinsics | `assert(Felt)`, `assertz(Felt)`, `assert_eq(Felt, Felt)` | Validation (`assert` fails unless the felt equals 1; `assertz` fails unless it equals 0) |
 
 ## Asset Handling
 
-`Asset` is now a two-word value:
+`Asset` is a two-word value (`key` + `value`):
 
-**Constructor**: `Asset::new(word)` creates an Asset from a Word.
-
-See [miden-bank bank-account](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for complete asset handling patterns including deposit, withdrawal, and balance tracking.
+**Constructor**: `Asset::new(key, value)` builds an Asset from its vault key word and value word (the arguments are `impl Into<Word>`, so e.g. `Asset::new(key_word, value_word)` or from `[Felt; 4]`).
 
 ```rust
 pub struct Asset {
@@ -82,31 +167,43 @@ let amount = asset.value[0];
 // Keep the asset key if you need to persist or compare the asset class
 let asset_key = asset.key;
 
-// Add asset to account vault (only from component methods, not note scripts; see pitfall P11)
+// Add asset to account vault (only from component methods, not note scripts — see pitfall P11)
 native_account::add_asset(asset);
 
-// Remove asset from account vault
-native_account::remove_asset(asset.clone());
+// Remove asset from account vault (Asset is Copy, no clone needed)
+native_account::remove_asset(asset);
 ```
 
 ## P2ID Output Note Creation
 
-To send assets to another account, create a P2ID (Pay-to-ID) output note. See [miden-bank bank-account](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) `create_p2id_note()` for a complete working implementation.
+To send assets to another account, create a P2ID (Pay-to-ID) output note. The sequence is:
+
+1. Build the recipient with `note::build_recipient(serial_number, script_root, inputs)`.
+2. Create the note with `output_note::create(tag, note_type, recipient)`, which returns a `NoteIdx`.
+3. Move the asset out of the vault and onto the note with `native_account::remove_asset(asset)` + `output_note::add_asset(asset, note_idx)`.
+
+Because a note script cannot call `native_account::*` (pitfall P11), P2ID creation lives inside an account-component method. See the rust-sdk-pitfalls skill for the exact constants and safety rules: P8 (`note::build_recipient`), P9 (P2ID script root — prefer `script_root()`, do not hardcode), and P10 (constructing `NoteType` via `NoteType::from(felt!(...))`).
 
 ## Cross-Component Dependencies
 
-To call another component's methods from a note or tx script, two Cargo.toml sections are needed. See [increment-note/Cargo.toml](../../../contracts/increment-note/Cargo.toml) for a working example showing both `[package.metadata.miden.dependencies]` and `[package.metadata.component.target.dependencies]`.
+To call another component's methods from a note or tx script, declare the dependency in your `miden-project.toml` in **two places**:
 
-Then import the bindings in your Rust code. See [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) line 13 for the import pattern: `use crate::bindings::miden::target_component::target_component;`
+- `[dependencies]` — a normal path (or registry) dependency on the component crate: `counter-account = { path = "../counter-account" }`.
+- `[package.metadata.miden.dependencies]` — the generated WIT for the component: `counter-account = { wit = "../counter-account/target/generated-wit/" }`. The WIT is produced by building the dependency component first.
+
+See [increment-note/miden-project.toml](../../../contracts/increment-note/miden-project.toml) for a working example showing both sections.
+
+Then expose the dependency's methods on the consuming account by declaring an `#[account(package::Interface)]` wrapper (`#[account(counter_account::CounterContract)] pub struct Wallet;`) and calling methods on the injected `account` parameter. The package name is the dependency's Rust-style name (`-` replaced with `_`, so `counter-account` → `counter_account`) and `Interface` is its exported WIT interface in UpperCamelCase (`CounterContract`). See [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs).
 
 ## Common Type Conversions
 
 ```rust
 // Felt from integer
 let f = felt!(42);                     // preferred for literals in contract code
-let f = Felt::new(42);                 // construct a Felt from a u64
-let f = Felt::from_u32(42);
-let f = Felt::from_canonical_checked(42).unwrap();
+let f = Felt::new(42).unwrap();        // fallible: Felt::new returns Result<Felt, _>
+let f = Felt::new_unchecked(42);       // infallible, non-reducing form
+let f = Felt::from_u32(42);            // infallible (u32 always fits)
+let f = Felt::from_canonical_checked(42).unwrap(); // returns Option<Felt>
 
 // Word from Felts
 let w = Word::from([f0, f1, f2, f3]);
@@ -135,56 +232,57 @@ use alloc::vec::Vec;
 
 ## Cross-Component Note Pattern
 
-A note script reads from `active_note::*` and forwards work to a public account-component method via generated bindings. This is the canonical pattern for any note that updates account state, because note scripts cannot call `native_account::*` directly (see `rust-sdk-pitfalls` skill, P11).
+A note script reads from `active_note::*` and forwards work to a public account-component method through the `#[account(...)]` wrapper. This is the canonical pattern for any note that updates account state, because note scripts cannot call `native_account::*` directly (see `rust-sdk-pitfalls` skill, P11).
 
-The `#[note]` macro generates `TryFrom<&[Felt]>` for the note struct, so the note's serialized storage is deserialized into typed fields before the script runs. The `#[note_script]` method receives the deserialized note as `self` (by value) and never indexes a raw Felt slice manually. Alongside the required `Word` arg, the method may optionally accept a `&Account` or `&mut Account` parameter. See [compiler/sdk/base-macros/src/lib.rs](https://github.com/0xMiden/compiler/blob/main/sdk/base-macros/src/lib.rs) for the macro contract and [compiler/sdk/base-macros/src/note.rs](https://github.com/0xMiden/compiler/blob/main/sdk/base-macros/src/note.rs) for the generated deserialization (each named field is read via `<T as miden::felt_repr::FromFeltRepr>::from_felt_repr(...)` and EOF is asserted at the end).
+The `#[note]` macro deserializes the note's inputs into the typed note struct, so serialized note storage is turned into typed fields before the script runs. The `#[note_script]` method receives the deserialized note as `self` (by value) and never indexes a raw Felt slice manually. Alongside the required `Word` arg, the method may optionally accept an `#[account(...)]` wrapper reference (`&Wallet` or `&mut Wallet`). See [compiler/sdk/base-macros/src/lib.rs](https://github.com/0xMiden/compiler/blob/main/sdk/base-macros/src/lib.rs) for the macro contract and [compiler/sdk/base-macros/src/note.rs](https://github.com/0xMiden/compiler/blob/main/sdk/base-macros/src/note.rs) for the generated deserialization (each named field is read via `<T as miden::felt_repr::FromFeltRepr>::from_felt_repr(...)` and EOF is asserted at the end).
 
-Supported field types include `Felt`, the unsigned integer scalars (`u64`, `u32`, `u8`), `bool`, `Option<T>`, and `Vec<T>` via the `FromFeltRepr` trait (`compiler/sdk/field-repr/repr/src/lib.rs`), plus any user type that opts in with `#[derive(FromFeltRepr)]` (this is how `AccountId` supports the macro - see `compiler/sdk/base-sys/src/bindings/types.rs`). Do **not** use `Asset` or `Word` directly as note struct fields; those types do not currently derive `FromFeltRepr`. If you need asset-shaped data inside the note, flatten it into supported scalar fields and reconstruct inside the script, or keep it on the side as a separate `active_note::get_assets()` read.
+Supported field types include `Felt`, the unsigned integer scalars (`u64`, `u32`, `u8`), `bool`, `Option<T>`, and `Vec<T>` via the `FromFeltRepr` trait (`compiler/sdk/field-repr/repr/src/lib.rs`), plus any user type that opts in with `#[derive(FromFeltRepr)]` (this is how `AccountId` supports the macro — see `compiler/sdk/base-sys/src/bindings/types.rs`). Do **not** use `Asset` or `Word` directly as note struct fields; those types do not currently derive `FromFeltRepr`. If you need asset-shaped data inside the note, flatten it into supported scalar fields and reconstruct inside the script, or keep it on the side as a separate `active_note::get_assets()` read.
 
-For Cargo.toml wiring (cross-component dependencies + bindings import), see "Cross-Component Dependencies" above. See [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) for the project-template's local example of the `#[note] struct + #[note] impl` macro form.
+For the Cargo.toml / `miden-project.toml` wiring (cross-component dependencies + `#[account(...)]` wrapper), see "Cross-Component Dependencies" above. See [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) for the project-template's local example of the `#[note] struct + #[note] impl` macro form.
 
-**Storage-free case** (sender + assets, single component call per asset): declare a unit struct (`#[note] struct DepositNote;`). The script reads `active_note::get_sender()` and iterates `active_note::get_assets()`, calling the component method per asset. The macro still generates the deserialization wrapper; for a unit struct it only asserts the storage Felt slice is empty.
+**Storage-free case** (unit struct, calls the account wrapper): declare a unit struct (`#[note] struct IncrementNote;`). The script receives the `#[account(...)]` wrapper and calls component methods on it — the counter's [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) is exactly this shape (`account.get_count()` / `account.increment_count()`). For a note that forwards assets, read `active_note::get_sender()` and iterate `active_note::get_assets()`, calling the component method per asset through the wrapper. The macro still generates the deserialization wrapper; for a unit struct it only asserts the note-input Felt slice is empty.
 
 **Typed-storage case** (note carries scripted data): declare named fields on the note struct. The macro deserializes them in declaration order, and the script accesses them via `self.<field>`. Illustrative shape:
 
 ```rust
+#[account(counter_account::CounterContract)]
+pub struct Wallet;
+
 #[note]
-struct DepositNote {
-    depositor: AccountId,
+struct TargetedNote {
+    target_account_id: AccountId,
 }
 
 #[note]
-impl DepositNote {
+impl TargetedNote {
     #[note_script]
-    pub fn run(self, _arg: Word) {
-        let assets = active_note::get_assets();
-        for asset in assets {
-            bank_account::deposit(self.depositor, asset);
-        }
+    fn run(self, _arg: Word, account: &mut Wallet) {
+        // `self.target_account_id` is deserialized from the note inputs;
+        // forward work to component methods on `account`.
     }
 }
 ```
 
-(`use` statements and crate attributes elided; see [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) for a complete file.) For a verified working example with an `&mut Account` parameter, see [compiler/examples/p2id-note/src/lib.rs](https://github.com/0xMiden/compiler/blob/main/examples/p2id-note/src/lib.rs) (`#[note] struct P2idNote { target_account_id: AccountId }`, where the script asserts `account.get_id() == self.target_account_id` and calls `account.receive_asset(asset)` for each attached asset).
+(`use` statements and crate attributes elided; see [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) for a complete file.) For a verified working example with a typed field and an `&mut` account-wrapper parameter, see [compiler/examples/p2id-note/src/lib.rs](https://github.com/0xMiden/compiler/blob/main/examples/p2id-note/src/lib.rs) (`#[note] struct P2idNote { target_account_id: AccountId }`, where the script asserts `account.get_id() == self.target_account_id` and calls `account.receive_asset(asset)` for each attached asset).
 
-**Component side that absorbs the call**: see [miden-bank bank-account](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for `deposit(...)` and `withdraw(...)` in a fuller example. The component method validates (felt-arithmetic safety, see `rust-sdk-pitfalls` P1), updates storage, and (for `withdraw`) creates a P2ID output note via the existing P2ID pattern. Note: miden-bank currently demonstrates an older raw-indexing variant for its withdraw-request note; treat the typed pattern shown above as the preferred shape for new note scripts.
+**Component side that absorbs the call**: the counter's `CounterContract` component exposes `get_count` / `increment_count` (see [counter-account/src/lib.rs](../../../contracts/counter-account/src/lib.rs)); the note calls those through the wrapper. A component method validates (felt-arithmetic safety, see `rust-sdk-pitfalls` P1), updates storage, and — for a withdraw-style flow — creates a P2ID output note via the P2ID pattern above.
 
-**Test wiring**: tests pass the serialized Felt representation of the note struct's fields through `NoteCreationConfig.storage`, in declaration order. See `rust-sdk-testing-patterns` skill, "Note Construction" section, for the helper that builds a note from a compiled `.masp` package and a populated `NoteCreationConfig`.
+**Test wiring**: tests pass the serialized Felt representation of the note struct's fields via `NoteBuilder::note_storage([...])`, in declaration order. See `rust-sdk-testing-patterns` skill, "Note Construction" section, for building a note from a compiled `.masp` package with `NoteScript::from_package` + `NoteBuilder`.
 
 ## Asset Receiving via Component Methods
 
-Note scripts cannot call `native_account::add_asset()` directly (see pitfall P11). The canonical pattern is for an account component to expose a public method that wraps `native_account::add_asset()`, and note scripts call that method via cross-component bindings.
+Note scripts cannot call `native_account::add_asset()` directly (see pitfall P11). The canonical pattern is for an account component to expose a public (trait) method that wraps `native_account::add_asset()`, and the note script calls that method through the `#[account(...)]` wrapper.
 
-See [miden-bank bank-account deposit()](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for the component side: the `deposit()` method validates the deposit, updates storage, and calls `native_account::add_asset()`.
-
-See [miden-bank deposit-note](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/deposit-note/src/lib.rs) for the note side: the note script calls `bank_account::deposit()` via generated bindings.
+Component side: a trait method (e.g. `deposit`) validates the deposit, updates storage, and calls `native_account::add_asset()`. Note side: the note declares `#[account(package::Interface)] pub struct Wallet;` and, inside `#[note_script] fn run(self, _arg: Word, account: &mut Wallet)`, calls `account.deposit(...)` on that wrapper. It is **not** a free `package::deposit()` call — the call goes through the injected `account`, exactly as the counter's [increment-note/src/lib.rs](../../../contracts/increment-note/src/lib.rs) calls `account.increment_count()`.
 
 ## Validation Checklist
 
 - [ ] `#![no_std]` and `#![feature(alloc_error_handler)]` at top of every contract
-- [ ] `crate-type = ["cdylib"]` in Cargo.toml
-- [ ] Correct `project-kind` in `[package.metadata.miden]`
-- [ ] Typed storage uses `StorageValue<T>` / `StorageMap<K, V>` with `get()` / `set()`
-- [ ] Cross-component deps in both `[package.metadata.miden.dependencies]` and `[package.metadata.component.target.dependencies]`
+- [ ] Account components use the three-part pattern: `#[component_storage]` struct + `#[component]` trait + `#[component]` impl (never `#[component]` on a struct)
+- [ ] `crate-type = ["cdylib"]` in `Cargo.toml`
+- [ ] Correct `[lib] kind` in `miden-project.toml` (`account-component` / `note` / `tx-script`) with the matching `namespace`
+- [ ] Typed storage uses `StorageValue<T>` / `StorageMap<K, V>` with `get()` / `set()`; slot names derive from `<package>::<namespace-interface>::<field>`
+- [ ] Notes/tx-scripts that call a component declare an `#[account(package::Interface)]` wrapper and call methods on the injected `account`
+- [ ] Cross-component deps declared in `miden-project.toml` under both `[dependencies]` (path) and `[package.metadata.miden.dependencies]` (wit)
 - [ ] Felt arithmetic validated before subtraction (see rust-sdk-pitfalls skill)
 - [ ] Felt comparisons use `.as_canonical_u64()` (see rust-sdk-pitfalls skill)

--- a/.claude/skills/rust-sdk-pitfalls/SKILL.md
+++ b/.claude/skills/rust-sdk-pitfalls/SKILL.md
@@ -44,39 +44,62 @@ if balance.as_canonical_u64() > threshold.as_canonical_u64() { ... }
 
 **Rule**: For quantity/business logic, ALWAYS convert to `.as_canonical_u64()` before using comparison operators.
 
-## P3: Function Argument Limit (4 Words / 16 Felts)
+## P3: Direct Call Boundary Passes At Most 16 Stack Felts (4 Words)
 
-**Severity**: Medium — causes compilation errors
+**Severity**: High — exceeding the 16-felt call boundary is a compile error
 
-Functions can receive at most 4 Words (16 Felts) as arguments.
+A direct cross-context / export / FPI call passes its parameters on the MASM operand stack, whose addressable window is 16 felts (4 Words, counting the canonical-ABI result pointer when present). Passing more than 16 flat felts across that boundary is a **compilation error**: after expanding 64-bit values and any result pointer, the flattened parameters must fit in 16 operand-stack felts. (Indirection for larger payloads via the advice provider is planned but not yet implemented, so today the limit is hard.)
 
 ```rust
-// PROBLEM — too many arguments
-fn process(a: Word, b: Word, c: Word, d: Word, e: Word) { ... } // > 4 Words!
+// COMPILE ERROR — flattens past 16 felts
+fn process(a: Word, b: Word, c: Word, d: Word, e: Word) { ... }
 
-// SOLUTION — pass fat types by reference
+// OK — keep signatures small, or pass aggregates by reference so each lowers to a pointer
 fn process(a: &Word, b: &Word, c: &Word, d: &Word, e: &Word) { ... }
 ```
 
 ## P4: Storage API Is Typed
 
-**Severity**: Medium — old examples no longer compile
+**Severity**: Medium — the wrong component shape does not compile
 
-The old `Value` / untyped `StorageMap` API is gone. Account storage is now:
+Account storage uses typed slots:
 
 - `StorageValue<T>` for a single typed slot
 - `StorageMap<K, V>` for typed maps
-- `get()` / `set()` methods instead of `.read()` / `.write()`
+- `get()` / `set()` methods
 - `K: WordKey`, `T: WordValue`, `V: WordValue`
 
-```rust
-#[component]
-struct CounterContract {
-    #[storage(description = "single typed slot")]
-    counter: StorageValue<Felt>,
+An account component is written in **three parts**: annotate the storage struct with `#[component_storage]`, the API `trait` with `#[component]`, and the `impl Trait for Storage` block with `#[component]`. See the working example in `contracts/counter-account/src/lib.rs`:
 
-    #[storage(description = "typed map")]
-    balances: StorageMap<AccountId, Felt>,
+```rust
+// 1. Storage struct — annotated #[component_storage], NOT #[component].
+//    Applying #[component] to a struct is a hard compile error.
+#[component_storage]
+struct CounterContractStorage {
+    #[storage(description = "counter contract storage map")]
+    count_map: StorageMap<Word, Felt>,
+}
+
+// 2. API trait — defines the exported interface.
+#[component]
+trait CounterContract {
+    fn get_count(&self) -> Felt;
+    fn increment_count(&mut self) -> Felt;
+}
+
+// 3. Implementation — the behavior, wired to the storage struct.
+#[component]
+impl CounterContract for CounterContractStorage {
+    fn get_count(&self) -> Felt {
+        let key = Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]);
+        self.count_map.get(key)
+    }
+    fn increment_count(&mut self) -> Felt {
+        let key = Word::new([felt!(0), felt!(0), felt!(0), felt!(1)]);
+        let new_value = self.count_map.get(key) + felt!(1);
+        self.count_map.set(key, new_value);
+        new_value
+    }
 }
 ```
 
@@ -88,15 +111,23 @@ If you need custom keys or values, implement `WordKey` / `WordValue` by converti
 
 Storage slot names follow a strict pattern. Getting it wrong often returns the default value silently.
 
-**Pattern**: `[component_package_or_name]::[snake_case(component_struct)]::[field_name]`
+**Pattern**: `[package_name]::[namespace_interface_segment]::[field_name]`
 
-**Conversion rule**: Replace characters outside `[A-Za-z0-9_]` with `_` in the package or component name. The package comes from `[package.metadata.component] package = "..."`, with any `@version` suffix ignored.
+**Where the segments come from**: The `#[component_storage]` macro (NOT `#[component]`) processes the `#[storage]` fields and derives slot names. It loads `miden-project.toml` (next to your `Cargo.toml`, NOT `Cargo.toml` itself):
 
-| Package in Cargo.toml | Component Struct | Field | Storage Slot Name |
-|----------------------|------------------|-------|-------------------|
-| `miden:counter-account` | `CounterContract` | `count_map` | `miden_counter_account::counter_contract::count_map` |
-| `miden:bank-account` | `BankAccount` | `balances` | `miden_bank_account::bank_account::balances` |
-| `miden:bank-account` | `BankAccount` | `initialized` | `miden_bank_account::bank_account::initialized` |
+- **First segment** = `[package] name`.
+- **Middle segment** = the *interface segment* of the `[lib] namespace` value. The namespace is a fully-qualified component id `namespace:package/interface@version`; the interface segment sits between the last `/` and the `@`. This is deliberately decoupled from the Rust storage-struct name, so renaming the private struct cannot change deployed slot names. The struct name (`CounterContractStorage`, …) does NOT appear in the slot name.
+- **Last segment** = the `#[storage]` field name.
+
+**Conversion rule**: Each segment is sanitized — any `@version` suffix is stripped, the interface segment is passed through `snake_case`, and characters outside `[A-Za-z0-9_]` are replaced with `_` (an empty or leading-`_` segment is prefixed with `x`). Project package names are conventionally kebab-case (e.g. `counter-account`), so the first segment is that name with hyphens replaced by `_` — it does NOT equal the package name verbatim (`counter-account` → `counter_account`).
+
+| `[package] name` | `[lib] namespace` | Field | Storage Slot Name |
+|------------------|-------------------|-------|-------------------|
+| `counter-account` | `miden:counter-account/counter-contract@0.1.0` | `count_map` | `counter_account::counter_contract::count_map` |
+
+The integration code depends on this exact name. In `integration/src/helpers.rs`, `counter_storage_slot()` builds it via `StorageSlotName::new("counter_account::counter_contract::count_map")`; a mismatch there reads the default value instead of the seeded one.
+
+**Caveat (toolchain-version dependent)**: This naming is a property of the Rust SDK contract macros, which live in the `miden-base-macros` crate (0.13.0, part of the Rust SDK family alongside `miden` and `miden-base-sys`, all 0.13.0; the separate compiler / `cargo-miden` workspace is versioned 0.9.0). Do not conflate these with the protocol/network version (v0.15). The slot-naming algorithm — `package_name::snake_case(interface_segment)::field`, with non-`[A-Za-z0-9_]` mapped to `_` and `@version` stripped — is stable, but verify against your installed toolchain rather than assuming a protocol version.
 
 ## P6: No-std Environment
 
@@ -112,11 +143,11 @@ extern crate alloc;
 use alloc::vec::Vec;
 ```
 
-## P7: Asset ABI Is Two Words, Not One
+## P7: Rust SDK `Asset` Is Two Words (Key + Value)
 
-**Severity**: Medium — old `asset.inner[...]` code is stale
+**Severity**: Medium — reconstructing an asset from raw `asset.inner[...]` offsets is wrong
 
-`Asset` is now:
+In the Rust SDK (`miden::Asset` / `miden_base_sys::bindings::Asset`), an `Asset` is encoded as two words:
 
 ```rust
 pub struct Asset {
@@ -133,13 +164,15 @@ let amount = asset.value[0];
 let asset_key = asset.key;
 ```
 
-Do not assume the old single-word asset layout. Use `asset.key` and `asset.value`, or protocol helpers, instead of reconstructing from old `asset.inner[...]` offsets.
+Use `asset.key` and `asset.value` (or protocol helpers) rather than reconstructing an asset from raw `asset.inner[...]` offsets.
 
-## P8: `Recipient::compute` Was Removed
+**SDK vs protocol `Asset`**: the two-word `{key, value}` form is the Rust SDK ABI type. At the protocol layer, `Asset` is an enum `{ Fungible, NonFungible }`, and the vault words are obtained via `to_key_word()` / `to_value_word()`. Reading the fungible amount from `value[0]` is correct on both sides.
 
-**Severity**: Medium — causes compilation errors after upgrading
+## P8: Build Recipients with `note::build_recipient`
 
-Building recipients now goes through the note binding:
+**Severity**: Medium — calling a nonexistent `Recipient::compute` fails to compile
+
+Build recipients through the note binding:
 
 ```rust
 extern crate alloc;
@@ -152,58 +185,68 @@ let recipient = note::build_recipient(
 );
 ```
 
-## P9: P2ID Note Root Hardcoding
+`note::build_recipient` is the Rust SDK alias for the host function `miden::protocol::note::compute_and_store_recipient`, which computes and stores the recipient in one step. You can call either name.
+
+## P9: P2ID Note Root — Prefer `script_root()`, Do Not Hardcode
 
 **Severity**: Low-Medium — breaks after miden-standards updates
 
-Creating P2ID output notes requires the MAST root digest of the P2ID script. This is typically hardcoded as a constant.
+Creating P2ID output notes requires the MAST root of the P2ID script. The root changes whenever the P2ID script or the assembler/hashing changes, so a hardcoded literal is fragile and unverifiable.
 
-For any note that is being created within the compiler code, the MAST root digest is needed. Below you find the example of a P2ID note
+**Source of truth**: Use `P2idNote::script_root()` from `miden-standards` (returns a `NoteScriptRoot`, a `Word` newtype convertible via `.into()`). Derive the root from the dependency rather than embedding a literal, and re-derive after any dependency bump.
 
 ```rust
-fn p2id_note_root() -> Digest {
-    Digest::from_word(
-        Word::try_from([
-            13362761878458161062_u64,
-            15090726097241769395_u64,
-            444910447169617901_u64,
-            3558201871398422326_u64,
-        ])
-        .unwrap(),
-    )
+use miden_standards::note::P2idNote;
+
+// script_root() returns a NoteScriptRoot (a Word newtype); convert to Word when needed.
+let p2id_root: Word = P2idNote::script_root().into();
+```
+
+**If you must embed a constant** (e.g., inside compiler/contract code that cannot call into miden-standards), regenerate it from the current `miden-standards` version and verify it after every update. The four-limb literal below is ILLUSTRATIVE only — it will not match your build and must not be copied as-is:
+
+```rust
+// ILLUSTRATIVE ONLY — will not match your build. Regenerate from
+// P2idNote::script_root() for your pinned miden-standards version.
+fn p2id_note_root() -> Word {
+    Word::try_from([
+        13362761878458161062_u64,
+        15090726097241769395_u64,
+        444910447169617901_u64,
+        3558201871398422326_u64,
+    ])
+    .unwrap()
 }
 ```
 
-**Risk**: If miden-standards updates the P2ID script, this digest becomes invalid and withdrawals silently fail.
+**Risk**: If miden-standards updates the P2ID script, any hardcoded digest becomes invalid and withdrawals silently fail.
 
-**Mitigation**: Use `P2idNote::script_root()` from miden-standards if available, or verify the hardcoded root matches the current version after dependency updates.
-
-**NoteType for P2ID**: P2ID output notes created in contract code should use the private note type value via `NoteType::from(felt!(2))` (see P10). Using the public note type triggers an opaque "missing details in advice provider" error at execution time. See [miden-bank withdraw](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for the working pattern.
+**NoteType for P2ID**: P2ID output notes created in contract code are constructed with `NoteType::from(felt!(...))` — `felt!(0)` for private, `felt!(1)` for public (see P10). In v0.15 the kernel rejects any note type other than `0` (private) or `1` (public) with `ERR_NOTE_INVALID_TYPE`. A common working pattern reads the note type from an input note's storage and forwards it through `NoteType::from(note_type)`.
 
 ## P10: NoteType Variants Unavailable in Compiler SDK
 
-**Severity**: Medium -- causes compilation errors
+**Severity**: Critical -- wrong values panic at runtime, named variants cause compilation errors
 
-Named enum variants (`NoteType::Private`, `NoteType::Public`, `NoteType::Encrypted`) don't exist in contract code. Construct via `NoteType::from()`:
+Named enum variants (`NoteType::Private`, `NoteType::Public`) don't exist in contract code — the SDK `NoteType` is an unvalidated transparent `Felt` wrapper. Construct via `NoteType::from()`:
 
 | NoteType | Value |
 |----------|-------|
+| Private (default) | `NoteType::from(felt!(0))` |
 | Public | `NoteType::from(felt!(1))` |
-| Private | `NoteType::from(felt!(2))` |
-| Encrypted | `NoteType::from(felt!(3))` |
 
-See [miden-bank bank-account](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/bank-account/src/lib.rs) for `NoteType::from(note_type)` usage.
+**Note-type encoding**: the note type is 1-bit — `Private = 0` (the protocol default) and `Public = 1`. Only these two values exist; there is no `Encrypted` type. The SDK wrapper does no validation, so an out-of-range value (e.g. `felt!(2)` or `felt!(3)`) is not caught at compile time — the kernel rejects it at execution time with `ERR_NOTE_INVALID_TYPE` (it asserts `note_type <= 1`).
+
+When a note forwards a caller-supplied note type, read it from the note's storage and pass it straight into `NoteType::from(note_type)`.
 
 ## P11: Note Scripts Cannot Call Native Account Functions
 
 **Severity**: High -- causes runtime failures
 
-Note scripts cannot call `native_account::add_asset()` or other `native_account::` functions directly. The kernel's `authenticate_account_origin` check rejects these calls from a note context. Instead, note scripts must call an account component method, which then calls `native_account::add_asset()` internally.
+Note scripts cannot call `native_account::add_asset()` or other `native_account::` functions directly. The kernel's `authenticate_account_origin` check rejects these calls from a note context. Instead, note scripts must call an account component method (through the `#[account(...)]` wrapper), which then performs the privileged `native_account::` operation internally.
 
-See [miden-bank deposit-note](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/contracts/deposit-note/src/lib.rs) for the correct pattern: the note script calls `bank_account::deposit()`, which internally calls `native_account::add_asset()`.
+See `contracts/increment-note/src/lib.rs` for the wrapper pattern: the note declares its consuming account via `#[account(counter_account::CounterContract)] pub struct Wallet;` and, inside `#[note_script] fn run(self, _arg: Word, account: &mut Wallet)`, calls the component methods on that wrapper (`account.get_count()`, `account.increment_count()`) rather than any `native_account::` function directly. Any asset mutation (e.g. `native_account::add_asset()`) must likewise live inside a component method that the note calls through the wrapper, never in the note script itself.
 
 ## P12: Note Inputs Are Immutable After Creation
 
 **Severity**: Low -- causes incorrect architecture
 
-The Felt slice that the `#[note]` macro deserializes into `self` is baked at note creation time and cannot be modified after creation. Design the typed note struct's field set and field order carefully before deployment; any later change is a breaking change for existing notes.
+Note inputs (the Felt data the `#[note]` macro deserializes into `self`, read at runtime via `active_note::get_storage()`) are baked at note creation time and cannot be modified after creation. Design the typed note struct's field set and field order carefully before deployment; any later change is a breaking change for existing notes.

--- a/.claude/skills/rust-sdk-source-guide/SKILL.md
+++ b/.claude/skills/rust-sdk-source-guide/SKILL.md
@@ -24,7 +24,7 @@ This is the single highest-leverage practice for AI-assisted Miden development.
 
 **Build loop**: After every contract edit, run `cargo miden build --manifest-path contracts/<name>/Cargo.toml --release`. The project's build hook does this automatically. If the build fails:
 1. Read the error message
-2. Translate obvious SDK migration errors first:
+2. Translate obvious SDK/compiler errors first:
    - `.as_u64()` -> `.as_canonical_u64()`
    - `Recipient::compute(...)` -> `note::build_recipient(...)`
    - `Value` -> `StorageValue<T>`
@@ -33,7 +33,7 @@ This is the single highest-leverage practice for AI-assisted Miden development.
 4. Adapt the working pattern to your use case
 5. Rebuild
 
-**Test loop**: Write tests alongside contracts. Run full repo checks with `cargo make test` (or `cargo test -p integration --release` for a faster integration-only loop). When tests fail:
+**Test loop**: Write tests alongside contracts. Run `cargo test -p integration --release` (tests compile the contracts via `build_project_in_dir()`, so always build contracts before running them). When tests fail:
 1. Check the error — is it a build error, a runtime assertion, or a proof failure?
 2. For assertion failures: check felt arithmetic (modular wrapping) and storage slot naming
 3. For unexpected behavior: compare your code against the closest working example in source repos
@@ -51,7 +51,7 @@ The basic skills (rust-sdk-patterns, rust-sdk-testing-patterns, miden-concepts, 
 - When you find a useful pattern in source, extract just what you need — the exact API call, the exact data layout, the exact test setup.
 
 **Using sub-agents for exploration**:
-- Launch an explore sub-agent with a specific question: "Find how P2ID output notes are created in the miden-bank repository"
+- Launch an explore sub-agent with a specific question: "Find how P2ID output notes are created in the miden-bank example (tutorials/examples/miden-bank)"
 - The sub-agent searches, reads the relevant files, and returns a focused summary
 - Your main context stays clean for implementation
 
@@ -75,56 +75,61 @@ When stuck at any stage: search the source repos for a similar working pattern. 
 Clone these repos alongside your project for reference. Claude will explore them when needed for advanced patterns.
 
 ```bash
-# Required: contains standard note types and account components
-git clone --depth 1 --branch main https://github.com/0xMiden/miden-base.git ../miden-base
+# Required: protocol layer — standard note types and account components (crate: miden-protocol)
+git clone --branch v0.15.3 https://github.com/0xMiden/protocol.git ../protocol
 
-# Required: contains SDK, compiler, and 12 working examples
-git clone --depth 1 --branch main https://github.com/0xMiden/compiler.git ../compiler
+# Required: client API for deployment and chain interaction
+git clone --branch v0.15.2 https://github.com/0xMiden/rust-sdk.git ../rust-sdk
 
-# Required: contains client API for deployment and chain interaction
-git clone --depth 1 --branch main https://github.com/0xMiden/miden-client.git ../miden-client
+# Required: the Rust SDK macros + compiler, released as v0.9.0 (targets VM v0.23 /
+# protocol v0.15 and ships the guest SDK crate `miden` at 0.13, build tool `cargo-miden` at 0.9).
+# Clone the release tag directly.
+git clone --branch v0.9.0 https://github.com/0xMiden/compiler.git ../compiler
 
-# Recommended: complete working banking app with advanced patterns in the `examples/miden-bank` folder of the tutorials repo
-git clone --branch main https://github.com/0xMiden/tutorials.git ../tutorials
+# Recommended: complete working banking app with advanced patterns in `examples/miden-bank`.
+# Its v0.15 examples live on branch `kbg/chore/v15-migration` (PR #204) until they land on the
+# default branch; pin the reviewed commit for reproducibility.
+git clone --branch kbg/chore/v15-migration https://github.com/0xMiden/tutorials.git ../tutorials
+git -C ../tutorials checkout a255af7959a441d9a027178631c666949b4af086
 ```
 
-**Note**: These commands clone the stable `main` branch. Only use `--branch next` if the user explicitly requests the experimental/upcoming version of the compiler or source repos.
+**Note**: The compiler is **released as `v0.9.0`**. Don't conflate the version schemes: the network/protocol is **v0.15**, but the compiler workspace and the `cargo-miden` build tool are **`0.9.0`**, and the guest SDK crates (`miden`, `miden-base-macros`, `miden-base-sys`) are **`0.13.0`** — so contracts depend on `miden = "0.13"` and integration/tooling on `cargo-miden = "0.9"`. The compiler exposes `note::build_recipient` as an SDK-friendly alias for `compute_and_store_recipient`, so the API examples below resolve there. Use the pinned refs above — `compiler` `v0.9.0`, `protocol` `v0.15.3`, `rust-sdk` (client) `v0.15.2`, and `tutorials` pinned at commit `a255af7` on its v0.15 branch — rather than the default branches, since `tutorials`' default branch does not yet carry the v0.15 examples. `--depth 1` is intentionally omitted so you can check out other refs later if needed.
 
 ### `compiler/` — The Rust-to-MASM Compiler
 
 Contains the SDK that powers `#[component]`, `#[note]`, and `#[tx_script]` macros.
 
-- **`examples/`** — 12 working examples covering every SDK pattern: account components, note scripts, transaction scripts, authentication components, wallets, faucets, storage. These are the most reliable reference for "how to write X" questions.
+- **`examples/`** — 12 working examples covering core SDK patterns: account components, note scripts, transaction scripts, authentication components (NoAuth, RPO Falcon512), wallets, and storage. These are the most reliable reference for "how to write X" questions. Note: there is no faucet example here — for faucet reference, use `crates/miden-standards/src/account/faucets/fungible/mod.rs` (the `FungibleFaucet` component) in the protocol repo, or the compiler's `tests/integration/src/sdk/base/faucet.rs` faucet binding test.
 
 **WARNING**: Stay in `examples/` only. Do NOT explore compiler internals (`sdk/`, `codegen/`, etc.) — they are implementation details that will confuse the agent and lead to incorrect code.
 
 **Explore when**: Writing any new contract type, finding working code examples for patterns not covered by skills.
 
-### `miden-base/` — Protocol Layer and Standard Library
+### `protocol/` — Protocol Layer and Standard Library
 
-Contains the protocol specification, standard components, and standard note types.
+The protocol repo (`github.com/0xMiden/protocol`; primary crate `miden-protocol`). Contains the protocol specification, standard components, and standard note types.
 
-- **`crates/miden-standards/`** — Standard note types (P2ID, P2IDE, SWAP, BURN, MINT) and standard account components (BasicWallet, BasicFungibleFaucet, authentication components). Explore to understand note flow patterns and data layouts.
+- **`crates/miden-standards/`** — Standard note types (P2ID, P2IDE, SWAP, PSWAP, BURN, MINT) and standard account components (BasicWallet, FungibleFaucet, authentication components). Explore to understand note flow patterns and data layouts.
 - **`crates/miden-protocol/asm/kernels/transaction/`** — The MASM transaction kernel. Every Rust SDK function (e.g., `native_account::add_asset`, `output_note::create`, `faucet::mint`) maps to a procedure defined here. Start with `api.masm` to find the procedure signature and stack contract, then read the implementation in `lib/` (e.g., `lib/output_note.masm`, `lib/account.masm`, `lib/epilogue.masm`). Useful for understanding exactly what happens under the hood -- for example, whether a function touches the vault, what the conservation check compares, or how note assets are tracked.
 - **`crates/miden-tx/`** — Rust execution engine (executor, prover, host). Orchestrates transaction execution but rarely needed for understanding contract behavior. Explore only if debugging execution infrastructure or host-level behavior.
-- **`crates/miden-testing/`** — MockChain implementation internals. Explore when you need to understand testing infrastructure beyond what the testing-patterns skill covers.
+- **`crates/miden-testing/`** — MockChain implementation internals. Explore when you need to understand testing infrastructure beyond what the rust-sdk-testing-patterns skill covers.
 
 **Note**: Standard components (BasicWallet, etc.) are MASM-only and not callable from Rust SDK (see [compiler#936](https://github.com/0xMiden/compiler/issues/936)). Explore miden-standards to understand note flows and data layouts, not for finding callable Rust APIs.
 
 **Explore when**: Understanding note flows, P2ID/SWAP/faucet data layouts, or what SDK functions actually do under the hood (via the kernel MASM).
 
-### `miden-client/` — Client Library
+### `rust-sdk/` — Client Library
 
-Contains the Rust API for deploying contracts and interacting with the Miden network.
+The client repo (`github.com/0xMiden/rust-sdk`). Contains the Rust API for deploying contracts and interacting with the Miden network.
 
 - Rust client for building transactions, syncing state, managing accounts and notes
 - CLI tool source code for reference on client usage patterns
 
 **Explore when**: Deploying contracts to testnet, submitting transactions, syncing state, managing notes on-chain.
 
-### `miden-bank/` — Working Example Application
+### `tutorials/examples/miden-bank/` — Working Example Application
 
-A complete banking application built with the Rust SDK. Demonstrates advanced patterns that go beyond the basic skills.
+A complete banking application built with the Rust SDK, located at `examples/miden-bank/` inside the cloned tutorials repo. Demonstrates advanced patterns that go beyond the basic skills.
 
 - Multiple contract types working together (account, deposit note, withdraw note, tx script)
 - Advanced patterns: `StorageMap<K, V>` + `StorageValue<T>` composition, felt arithmetic safety, cross-component calls, P2ID output note creation from within contracts
@@ -138,16 +143,16 @@ A complete banking application built with the Rust SDK. Demonstrates advanced pa
 
 | Building This | Explore These Repos | What to Look For |
 |---|---|---|
-| Account component with storage | `compiler/` examples, `miden-bank/` contracts | `StorageMap<K, V>` / `StorageValue<T>` patterns, pub method signatures |
-| Note script | `compiler/` examples, `miden-bank/` contracts | `#[note_script]` pattern, cross-component calls, note storage parsing |
-| Transaction script | `compiler/` examples, `miden-bank/` contracts | `#[tx_script]` pattern, Account binding import |
-| Authentication component | `compiler/` examples | Auth component patterns (NoAuth, Falcon512, ECDSA) |
-| Faucet (token minting) | `compiler/` examples | BasicFungibleFaucet example, mint/burn pattern |
-| P2ID output notes | `miden-bank/` contracts, `miden-base/` standards (data layouts) | `note::build_recipient`, script root, `output_note` creation |
-| Swap notes | `miden-base/` standards (data layouts) | SwapNote data layout, tag construction, payback flow |
-| Multi-step tests | `miden-bank/` integration tests | Init → operate → verify flow, output note verification |
-| Client deployment | `miden-client/` | TransactionRequestBuilder, sync, submit patterns |
-| SDK function internals | `miden-base/` kernel (`crates/miden-protocol/asm/kernels/transaction/`) | `api.masm` for procedure signatures, `lib/*.masm` for implementations |
+| Account component with storage | `compiler/` examples, `tutorials/examples/miden-bank/` contracts | `StorageMap<K, V>` / `StorageValue<T>` patterns, pub method signatures |
+| Note script | `compiler/` examples, `tutorials/examples/miden-bank/` contracts | `#[note_script]` pattern, cross-component calls, note storage parsing |
+| Transaction script | `compiler/` examples, `tutorials/examples/miden-bank/` contracts | `#[tx_script]` pattern, Account binding import |
+| Authentication component | `compiler/` examples | Auth component patterns (NoAuth, RPO Falcon512) |
+| Faucet (token minting) | `protocol/` standards (`crates/miden-standards/src/account/faucets/fungible/mod.rs`), `compiler/` faucet binding test (`tests/integration/src/sdk/base/faucet.rs`) | `FungibleFaucet` component, `FungibleFaucet::builder()`, mint/burn pattern |
+| P2ID output notes | `tutorials/examples/miden-bank/` contracts, `protocol/` standards (data layouts) | `note::build_recipient`, script root, `output_note` creation |
+| Swap notes | `protocol/` standards (data layouts) | SwapNote data layout, tag construction, payback flow |
+| Multi-step tests | `tutorials/examples/miden-bank/` integration tests | Init → operate → verify flow, output note verification |
+| Client deployment | `rust-sdk/` | TransactionRequestBuilder, sync, submit patterns |
+| SDK function internals | `protocol/` kernel (`crates/miden-protocol/asm/kernels/transaction/`) | `api.masm` for procedure signatures, `lib/*.masm` for implementations |
 
 ---
 
@@ -159,20 +164,19 @@ These patterns go beyond what the basic skills cover. For each, the source repos
 Accounts can include standard components (BasicWallet, authentication) alongside custom logic at account creation time. Standard components are MASM-only (not callable from Rust), but they are composed into accounts via the testing/deployment infrastructure. The `compiler/` examples show how to compose accounts with multiple components.
 
 ### Output Note Creation from Contracts
-Create output notes (like P2ID) from within contract code. Requires building a recipient with `note::build_recipient(serial_num, script_root, storage)` and then using `output_note::create(...)`. The `miden-bank/` withdraw pattern demonstrates this end-to-end.
+Create output notes (like P2ID) from within contract code. Requires building a recipient with `note::build_recipient(serial_num, script_root, storage)` and then using `output_note::create(...)`. The `tutorials/examples/miden-bank/` withdraw pattern demonstrates this end-to-end.
 
 ### Note Storage Protocol
-Notes carry storage data as a `Vec<Felt>` baked at creation time. The `#[note]` macro generates a `TryFrom<&[Felt]>` for the note struct via the `FromFeltRepr` trait, so the `#[note_script]` method receives the deserialized note as `self` (by value); the script reads typed fields with `self.<field>` and never indexes the raw Felt slice.
-Attached assets are separate and should be read with `active_note::get_assets()`.
+A note's storage is exposed to its `#[note_script]` as a `Vec<Felt>` via `active_note::get_storage()`; the script reads and parses the items it needs by index. In `tutorials/examples/miden-bank/` the note structs are markers (not auto-populated from storage) and the script slices explicitly — e.g. the withdraw-request note asserts `storage.len() == 14`, then reconstructs the asset, serial number, tag, and note type from the felts. Attached assets are separate and are read with `active_note::get_assets()`.
 
 ### Atomic Swaps
-The standard SwapNote in `miden-base/` creates a payback P2ID note automatically when consumed. Explore the SwapNote builder to understand tag construction, storage layout, and the payback mechanism.
+The standard SwapNote in `protocol/` (`crates/miden-standards/src/note/swap.rs`) creates a payback P2ID note automatically when consumed. Explore the SwapNote builder to understand tag construction, storage layout, and the payback mechanism.
 
 ### Account Initialization
-Use `#[tx_script]` to initialize accounts before they accept operations. The `miden-bank/` init-tx-script calls `account.initialize()` to set an initialization flag, which is checked before every operation.
+Use `#[tx_script]` to initialize accounts before they accept operations. The `tutorials/examples/miden-bank/` init-tx-script calls `account.initialize()` to set an initialization flag, which is checked before every operation.
 
 ### Token Creation (Faucets)
-Faucet accounts mint and burn fungible or non-fungible tokens. The `compiler/` fungible-faucet example and `miden-base/` BasicFungibleFaucet standard component show how to create and manage tokens.
+Faucet accounts mint and burn tokens. The `protocol/` `FungibleFaucet` standard component (`crates/miden-standards/src/account/faucets/fungible/mod.rs`) shows how to create and manage fungible tokens; construct it via `FungibleFaucet::builder().name(..).symbol(..).decimals(..).max_supply(..).build()?`. There is no faucet example in `compiler/examples/`; for an SDK-level faucet binding reference use the compiler's `tests/integration/src/sdk/base/faucet.rs`.
 
 ### P2ID with Expiration (P2IDE)
-Send assets with a deadline — the sender can reclaim after the block height passes. The `compiler/` p2ide-note example and `miden-base/` P2IDE standard show the timelock pattern.
+Send assets with a deadline — the sender can reclaim after the block height passes. The `compiler/` p2ide-note example and `protocol/` P2IDE standard (`crates/miden-standards/src/note/p2ide.rs`) show the timelock pattern.

--- a/.claude/skills/rust-sdk-testing-patterns/SKILL.md
+++ b/.claude/skills/rust-sdk-testing-patterns/SKILL.md
@@ -1,25 +1,47 @@
 ---
 name: rust-sdk-testing-patterns
-description: Guide to testing Miden smart contracts with MockChain. Covers test setup, contract building, account/note creation, transaction execution, storage verification, faucet setup, output note verification, block numbering, multi-transaction tests, and asset-bearing notes. Use when writing, editing, or debugging Miden integration tests.
+description: Guide to testing Miden smart contracts with MockChain (Miden v0.15). Covers test setup, contract building, account/note creation, transaction execution, storage verification, faucet setup, output note verification, block numbering, multi-transaction tests, and asset-bearing notes. Use when writing, editing, or debugging Miden integration tests.
 ---
 
 # Miden Testing Patterns (MockChain)
+
+These patterns target Miden **v0.15** (`miden-client`/`miden-standards`/`miden-testing` 0.15.x).
+
+The **authoritative working example** in this project is the counter contract: [counter_test.rs](../../../integration/tests/counter_test.rs) is a complete test covering imports, MockChain setup, contract building, account creation with storage, note creation, transaction execution, and storage verification. Mirror it for the patterns below.
 
 ## Test File Setup
 
 Tests go in `integration/tests/`. All tests are async and use MockChain for local execution without a network.
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) for a complete working test covering imports, MockChain setup, contract building, account creation with storage, note creation, transaction execution, and storage verification.
+The v0.15 imports [counter_test.rs](../../../integration/tests/counter_test.rs) relies on are:
+
+```rust
+use std::{path::Path, sync::Arc};
+
+use integration::helpers::{build_project_in_dir, counter_storage_slot, COUNTER_STORAGE_KEY};
+use miden_client::{
+    account::{component::InitStorageData, AccountBuilder, AccountComponent, AccountType},
+    auth::AuthSchemeId,
+    crypto::RandomCoin,
+    note::NoteScript,
+    transaction::RawOutputNote,
+    Word,
+};
+use miden_standards::testing::note::NoteBuilder;
+use miden_testing::{AccountState, Auth, MockChain};
+```
 
 ## Step-by-Step Test Pattern
 
 ### 1. Initialize MockChain Builder
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) line 21 for the pattern: `let mut builder = MockChain::builder();`
+Start from `let mut builder = MockChain::builder();` (see [counter_test.rs](../../../integration/tests/counter_test.rs)).
 
 ### 2. Create Sender/Wallet Accounts
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 24-26 for the basic wallet pattern. For wallets with pre-funded assets, use `builder.add_existing_wallet_with_assets(Auth::BasicAuth { auth_scheme: AuthSchemeId::Falcon512Poseidon2 }, [FungibleAsset::new(faucet.id(), 100)?.into()])`.
+For a bare wallet use `builder.add_existing_wallet(Auth::BasicAuth { auth_scheme: AuthSchemeId::Falcon512Poseidon2 })` (see [counter_test.rs](../../../integration/tests/counter_test.rs)). For wallets with pre-funded assets, use `builder.add_existing_wallet_with_assets(Auth::BasicAuth { auth_scheme: AuthSchemeId::Falcon512Poseidon2 }, [FungibleAsset::new(faucet.id(), 100)?.into()])`.
+
+> Auth-scheme naming: `miden_client::auth` re-exports the same protocol enum under two names — `AuthScheme` (the protocol name) and `AuthSchemeId` (an alias). Both compile; the field is `Auth::BasicAuth { auth_scheme }`, and the variant `Falcon512Poseidon2` is the same on both. This project uses `AuthSchemeId::Falcon512Poseidon2`.
 
 ### 3. Set Up Faucets (for fungible assets)
 ```rust
@@ -29,83 +51,121 @@ let faucet = builder.add_existing_basic_faucet(
     },
     "TOKEN",     // token symbol
     1000,        // max supply
-    Some(10),    // total_issuance (None for 0)
+    Some(10),    // token_supply (None defaults to 0)
 )?;
 ```
 
+The 4th argument is `token_supply: Option<u64>` (an explicit `None` is treated as `0`).
+
 ### 4. Build Contracts
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 29-35 for the pattern using `build_project_in_dir`.
+Build each project from its directory with the `build_project_in_dir` helper, e.g. `let contract_package = Arc::new(build_project_in_dir(Path::new("../contracts/counter-account"), true)?);` (see [counter_test.rs](../../../integration/tests/counter_test.rs) and [integration/src/helpers.rs](../../../integration/src/helpers.rs) `build_project_in_dir`).
 
 ### 5. Create Account with Storage
 
 **Storage slot naming convention** (CRITICAL):
 ```
-[component_package_or_name]::[snake_case(component_struct)]::[field_name]
+<package_name>::<interface_segment>::<field_name>
 ```
 
-Examples:
-- Package `miden:counter-account`, component `CounterContract`, field `count_map` -> `miden_counter_account::counter_contract::count_map`
-- Package `miden:bank-account`, component `BankAccount`, field `balances` -> `miden_bank_account::bank_account::balances`
+The slot name is part of the on-chain storage ABI and is derived by the compiler's `#[component_storage]` macro, **not** from the Rust struct name:
+- `<package_name>` is the **bare** package name (`[package].name`), with no `miden:` org prefix.
+- `<interface_segment>` is the `[lib].namespace` **interface** segment — the text between the last `/` and the `@` in the namespace — snake_cased. Because it comes from the declared namespace, renaming the Rust struct cannot change the deployed slot name.
+- `<field_name>` is the Rust storage field's identifier (not its `description`).
 
-Rule: Replace characters outside `[A-Za-z0-9_]` with `_` in the package or component name.
+Characters outside `[A-Za-z0-9_]` are replaced with `_` in each segment.
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 38-54 for the current pattern: populate `InitStorageData`, build the component from the compiled package, then register the account with `builder.add_account_from_builder(...)`.
+Example: package `counter-account` with `[lib].namespace = "miden:counter-account/counter-contract@0.1.0"` (see [contracts/counter-account/miden-project.toml](../../../contracts/counter-account/miden-project.toml)) and storage struct `CounterContractStorage` (field `count_map`) yields the slot:
+- `counter_account::counter_contract::count_map`
+
+Note the middle segment is `counter_contract` (the interface segment from the namespace), **not** `counter_contract_storage` (the struct) and **not** `counter_account`, and there is no `miden_` org prefix. This is exactly the string [integration/src/helpers.rs](../../../integration/src/helpers.rs) passes to `StorageSlotName::new(...)` in `counter_storage_slot()`.
+
+The component's storage is declared with the v0.15 three-part component macro (`#[component_storage]` struct + `#[component]` trait + `#[component]` impl); the storage struct, not the trait, carries the `#[storage]` fields the slot names derive from. See the `rust-sdk-patterns` skill for the contract side.
+
+**Authoritative pattern** (from [counter_test.rs](../../../integration/tests/counter_test.rs)): build the `StorageSlotName`, seed the component's initial storage into `InitStorageData`, build the `AccountComponent` from the compiled package, then register the account with `builder.add_account_from_builder(...)`:
 
 ```rust
 let counter_storage_slot = counter_storage_slot()?;
 let mut init_storage_data = InitStorageData::default();
+// The counter's `count_map` is a `StorageMap<Word, Felt>`; seed its fixed key with 0
+// so the increment note finds an existing entry. `insert_map_entry(slot_name, key, value)`
+// takes three args: `slot_name: impl TryInto<StorageSlotName>`, `key`, `value`.
 init_storage_data.insert_map_entry(counter_storage_slot.clone(), COUNTER_STORAGE_KEY, 0_u64)?;
 
-let counter_component =
-    AccountComponent::from_package(&contract_package, &init_storage_data)?;
+let counter_component = AccountComponent::from_package(&contract_package, &init_storage_data)?;
 let counter_account = builder.add_account_from_builder(
     Auth::BasicAuth {
         auth_scheme: AuthSchemeId::Falcon512Poseidon2,
     },
     AccountBuilder::new([3_u8; 32])
-        .account_type(AccountType::RegularAccountImmutableCode)
-        .storage_mode(AccountStorageMode::Public)
+        .account_type(AccountType::Public)
         .with_component(counter_component),
     AccountState::Exists,
 )?;
 ```
 
-For a single-value contract slot (paired with `StorageValue<T>` on-chain) instead of a map:
+> Account model:
+> - `AccountType` is the visibility enum `{ Private, Public }`.
+> - Set account visibility via `.account_type(AccountType::Public | ::Private)` — there is no separate `.storage_mode(...)` / `AccountStorageMode` on the builder.
+> - Faucet-ness is determined by the installed components.
+
+For a **single-value** contract slot (a `StorageValue<Word>` field on-chain) instead of a map, seed it with `insert_value` — a value slot that has no schema default otherwise makes `AccountComponent::from_package` error with `InitValueNotProvided`:
+
 ```rust
+let value_slot = StorageSlotName::new("my_account::my_component::initialized")?;
 let mut init_storage_data = InitStorageData::default();
 init_storage_data.insert_value(
-    "miden_bank_account::bank_account::initialized",
-    0_u64,
+    StorageValueName::from_slot_name(&value_slot),
+    Word::default(), // zero Word (an uninitialized flag), NOT a bare integer
 )?;
 ```
 
+> Storage-seeding footgun: `InitStorageData::insert_value(name, value)` takes `value: impl Into<WordValue>`. The numeric `From` impls (`u8`/`u16`/`u32`/`u64`) produce a `WordValue::Atomic(string)` that the slot's schema parses — **not** a felt-positioned `Word`. Only `From<Felt>` yields `[felt, 0, 0, 0]`, and `From<Word>`/`From<[Felt; 4]>`/`From<[u32; 4]>` are fully-typed words. For a `StorageValue<Word>` slot whose contract reads index `[0]`, seed a `Word` (`Word::default()` for zero). A map slot (like the counter's `count_map`) is seeded per-entry with `insert_map_entry(...)` instead.
+
 ### 6. Create Notes
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 56-64 for basic note creation with `RandomCoin`, `NoteScript::from_package`, and `NoteBuilder`.
+Build notes with `NoteBuilder`, seeding the `RandomCoin` from the note-script root (see [counter_test.rs](../../../integration/tests/counter_test.rs)):
 
-For notes with assets and inputs:
 ```rust
-use miden_client::{asset::FungibleAsset, crypto::RandomCoin, note::NoteScript, Felt};
-use miden_standards::testing::note::NoteBuilder;
-
-let mut note_rng = RandomCoin::new(NoteScript::from_package(note_package.as_ref())?.root());
-let note = NoteBuilder::new(sender.id(), &mut note_rng)
+let mut note_rng = RandomCoin::new(Word::from(
+    NoteScript::from_package(note_package.as_ref())?.root(),
+));
+let counter_note = NoteBuilder::new(sender.id(), &mut note_rng)
     .package((*note_package).clone())
-    .add_assets([FungibleAsset::new(faucet.id(), 50)?.into()])
-    .note_storage([Felt::new(42), Felt::new(0)])?
     .build()?;
 ```
 
+For a note that also carries assets and inputs, configure the extra builder steps:
+
+```rust
+use miden_client::{asset::FungibleAsset, crypto::RandomCoin, note::NoteScript, Felt, Word};
+use miden_standards::testing::note::NoteBuilder;
+
+let note_script = NoteScript::from_package(note_package.as_ref())?;
+let mut note_rng = RandomCoin::new(Word::from(note_script.root()));
+let note = NoteBuilder::new(sender.id(), &mut note_rng)
+    .package((*note_package).clone())
+    .add_assets([FungibleAsset::new(faucet.id(), 50)?.into()])
+    .note_storage([Felt::from(42_u32), Felt::from(0_u32)])?
+    .build()?;
+```
+
+> `NoteScript::root()` returns a `NoteScriptRoot` newtype. `RandomCoin::new` needs a `Word`, so convert the root explicitly with `Word::from(...root())` (equivalently `...root().into()` or `...root().as_word()`).
+
+> `Felt::new(u64)` is **fallible** — it returns `Result<Felt, FeltFromIntError>`. `note_storage` takes `impl IntoIterator<Item = Felt>`, so build each felt with the infallible `Felt::from(42_u32)` for in-range literals (`From<u8>/From<u16>/From<u32>` are infallible); for a `u64` use `Felt::new(n)?` or `Felt::new_unchecked(n)`.
+
 ### 7. Add to MockChain and Build
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 66-70 for seeding the note and building the mock chain. `add_account_from_builder(...)` has already registered the account in the builder, so at this stage you usually only need to add notes.
+Register accounts (`add_account_from_builder(...)` already registered the counter account in Step 5) and seed notes with `builder.add_output_note(RawOutputNote::Full(counter_note.clone()))`, then `let mut mock_chain = builder.build()?;` (see [counter_test.rs](../../../integration/tests/counter_test.rs)).
 
 ### 8. Execute Transaction
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 73-82 for the full execution flow: `build_tx_context` -> `execute()` -> `add_pending_executed_transaction()` -> `prove_next_block()`. The single-transaction counter test does not call `apply_delta()` because `counter_account` is not reused after the build; final state is read from `mock_chain.committed_account(...)` after the block is proven. Multi-transaction tests that keep using the in-memory `Account` variable across steps should call `account.apply_delta(&executed.account_delta())?` after each `execute()` (see "Multi-Transaction Test Pattern" below).
+The full execution flow is `build_tx_context` -> `execute()` -> `add_pending_executed_transaction()` -> `prove_next_block()` (see [counter_test.rs](../../../integration/tests/counter_test.rs)). The single-transaction counter test does not call `apply_delta()` because `counter_account` is not reused after the build; final state is read from `mock_chain.committed_account(...)` after the block is proven. Multi-transaction tests that keep using the in-memory `Account` variable across steps should call `account.apply_delta(&executed.account_delta())?` after each `execute()` (see "Multi-Transaction Test Pattern" below).
 
 ### 9. Execute with Transaction Script
+
+A compiler project with `kind = "tx-script"` compiles to a `TransactionScript`-kind package, **not** an `Executable`. Because of that, `TransactionScript::from_package` and `Package::unwrap_program` do **not** apply to it: `from_package` calls `package.try_into_program()`, which returns `Err` for a non-executable package, and `unwrap_program` asserts the kind is `Executable` and **panics**. Build the script from the package's MAST forest plus its entry export instead:
+
 ```rust
 use miden_client::transaction::TransactionScript;
 
@@ -113,11 +173,14 @@ let tx_script_package = Arc::new(build_project_in_dir(
     Path::new("../contracts/my-tx-script"),
     true,
 )?);
-let program = tx_script_package.unwrap_program();
-let tx_script = TransactionScript::new((*program).clone());
+
+// Locate the entry export ("main"/"run", or the sole export) and build from parts, e.g. a
+// small helper that finds the entry procedure root in the MAST forest and calls
+// `TransactionScript::from_parts(package.mast.mast_forest().clone(), entrypoint)`.
+let tx_script = build_tx_script_from_package(tx_script_package.as_ref())?;
 
 let executed = mock_chain
-    .build_tx_context(account.clone(), &[], &[])?
+    .build_tx_context(account.id(), &[], &[])?
     .tx_script(tx_script)
     .build()?
     .execute()
@@ -129,18 +192,36 @@ mock_chain.prove_next_block()?;
 let updated_account = mock_chain.committed_account(account.id())?;
 ```
 
+> Reserve `TransactionScript::from_package(&package)?` (and the `#[doc(hidden)]` `unwrap_program()`) for packages that are genuinely `Executable`. For `kind = "tx-script"` compiler packages, use `from_parts` / a `build_tx_script_from_package`-style helper as above — `from_package` returns an error and `unwrap_program()` panics on them.
+
 ### 10. Verify Storage State
 
-See [counter_test.rs](../../../integration/tests/counter_test.rs) lines 84-96 for reading the committed account state and asserting on the result.
+Read state with `account.storage().get_item(&slot)` / `.get_map_item(&slot, key)` on an in-memory `Account` you keep `apply_delta`-current, or re-fetch the committed account with `mock_chain.committed_account(account.id())?` after `prove_next_block()` and assert on its storage. Map values come back as scalar words in `[value, 0, 0, 0]` layout, so read index `[0]` (see [counter_test.rs](../../../integration/tests/counter_test.rs)):
+
+```rust
+let count = mock_chain
+    .committed_account(counter_account.id())?
+    .storage()
+    .get_map_item(&counter_storage_slot, COUNTER_STORAGE_KEY)
+    .expect("Failed to get counter value from storage slot");
+assert_eq!(count[0].as_canonical_u64(), 1);
+```
 
 ### 11. Verify Output Notes
 
-**Important**: `add_output_note()` is only available on `MockChainBuilder` (before `build()`); use it to seed the chain with existing notes. To verify output notes from a transaction, use `extend_expected_output_notes()` on `TxContextBuilder`:
+**Important**: `add_output_note()` is only available on `MockChainBuilder` (before `build()`) — use it to seed the chain with existing notes. To verify output notes from a transaction, use `extend_expected_output_notes()` on `TxContextBuilder`:
 
 ```rust
-use miden_client::{note::{Note, NoteAssets, NoteMetadata, NoteRecipient}, transaction::RawOutputNote};
+use miden_client::{
+    note::{Note, NoteType, PartialNoteMetadata},
+    transaction::RawOutputNote,
+};
 
-let expected_note = Note::new(expected_assets, expected_metadata, expected_recipient);
+// Note::new takes a PartialNoteMetadata (sender + note_type + tag).
+// Build it with PartialNoteMetadata::new(sender, note_type),
+// then optionally `.with_tag(tag)` (the tag defaults to NoteTag::default()).
+let partial_metadata = PartialNoteMetadata::new(sender, NoteType::Public).with_tag(tag);
+let expected_note = Note::new(expected_assets, partial_metadata, expected_recipient);
 
 let tx_context = mock_chain
     .build_tx_context(account.id(), &[note.id()], &[])?
@@ -151,74 +232,70 @@ let tx_context = mock_chain
 let executed = tx_context.execute().await?;
 ```
 
+> Note metadata:
+> - `Note::new(assets, partial_metadata, recipient)` takes a `PartialNoteMetadata` (sender/type/tag only); there is no `Into` conversion on the parameter.
+> - For attachment-bearing notes use `Note::with_attachments(assets, partial_metadata, recipient, attachments)` (attachments are `NoteAttachments`).
+
 ## MockChain Note Interaction
 
 Notes flow through MockChain in four steps:
 
-1. **Build** the note from a compiled `.masp` package (see "Note Construction" below) or via `NoteBuilder`.
+1. **Build** the note from a compiled `.masp` package via `NoteBuilder` (see "Note Construction" below).
 2. **Seed** with `MockChainBuilder::add_output_note(RawOutputNote::Full(note.clone()))` BEFORE `builder.build()`. This places the note on the chain so a later transaction can consume it. `add_output_note(...)` is only available on the builder; once `builder.build()` returns the `MockChain`, output notes can only appear as the result of executing a transaction. `RawOutputNote` is re-exported from `miden_client::transaction`.
 3. **Consume** by passing the note ID to `mock_chain.build_tx_context(account, &[note.id()], &[])`. The transaction's note-script execution reads the consumed note's storage and assets.
 4. **Verify** expected output notes with `.extend_expected_output_notes(vec![RawOutputNote::Full(expected.clone())])` on the `TxContextBuilder`. `tx_context.execute().await?` will assert the produced output notes match.
 
 After `execute()` and before `add_pending_executed_transaction(...) + prove_next_block()`: if a later step will keep using the in-memory `Account` variable (for example, to build another `tx_context` or assert account state directly), call `account.apply_delta(&executed.account_delta())?` to keep the variable in sync with the chain. Post-block reads should use `mock_chain.committed_account(account.id())?` (see Step 8 above and "Multi-Transaction Test Pattern" below). For block advancement and reference-block semantics, see "MockChain Block Numbering" below.
 
-End-to-end multi-note example: see [miden-bank withdraw_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/withdraw_test.rs) for seeding deposit + withdraw-request notes via `add_output_note(RawOutputNote::Full(...))` before `builder.build()`, then consuming the withdraw-request note and asserting an expected P2ID output note via `extend_expected_output_notes(...)` plus `prove_next_block()`. See [miden-bank deposit_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/deposit_test.rs) for the simpler single-note consume + prove cycle.
-
 ## Multi-Transaction Test Pattern
 
 For contracts requiring initialization before use, each step usually needs its own `execute()` → `add_pending_executed_transaction()` → `prove_next_block()` cycle. Fetch the committed account or note state from `mock_chain` between steps before building the next context.
 
-Call `account.apply_delta(&executed.account_delta())?` after each `execute()` to keep the in-memory `Account` variable in sync with the chain whenever later steps reuse it (for `build_tx_context(...)`, asserting account state directly, etc.). The miden-bank tutorial tests follow this pattern between every `execute()` and `prove_next_block()`. If the test only reads final state via `mock_chain.committed_account(...)` after the last `prove_next_block()` and never reuses the in-memory variable, `apply_delta` is unnecessary; see [counter_test.rs](../../../integration/tests/counter_test.rs).
-
-See [miden-bank withdraw_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/withdraw_test.rs) for a complete multi-transaction test demonstrating: initialize bank → deposit assets → withdraw assets (3 sequential transactions with state verification between each step).
-
-See [miden-bank deposit_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/deposit_test.rs) for an end-to-end asset-bearing note test.
+`apply_delta()` is needed whenever you keep reading from / reusing the **same in-memory `Account`** across transactions — whether they land in the same block or in separate blocks. Call `account.apply_delta(&executed.account_delta())?` after each `execute()` (each followed by `add_pending_executed_transaction` + `prove_next_block`) so later local reads like `account.storage().get_map_item(...)` see the latest state. If you instead re-fetch via `mock_chain.committed_account(...)` after `prove_next_block()`, you can skip `apply_delta()` — that is the single-transaction case shown in [counter_test.rs](../../../integration/tests/counter_test.rs), which reads final state only after the last `prove_next_block()` and never reuses the in-memory variable.
 
 ## MockChain Block Numbering
 
-Genesis is block 0. Each `prove_next_block()` advances the block number by 1. In contract code, `tx::get_block_number()` returns the **reference block**: the last proven block at the time the transaction started, not the block the transaction will be included in.
+Genesis is block 0. Each `prove_next_block()` advances the block number by 1. In contract code, `tx::get_block_number()` returns the **reference block** — the last proven block at the time the transaction started, not the block the transaction will be included in.
 
 ## Note Construction
 
-Prefer `NoteBuilder` (or mirror its logic with compiled `.masp` package files) for creating notes in tests. Start from `NoteBuilder::new(sender.id(), &mut note_rng)`, then configure `.package(...)`, optional `.add_assets(...)`, optional `.note_storage(...)`, and finally `.build()`. See [counter_test.rs](../../../integration/tests/counter_test.rs) for the working pattern.
+Prefer `NoteBuilder` for creating notes in tests. Start from `NoteBuilder::new(sender.id(), &mut note_rng)`, then configure `.package(...)`, optional `.note_type(...)`, optional `.tag(...)`, optional `.add_assets(...)`, optional `.note_storage(...)?`, optional `.serial_number(...)`, and finally `.build()?`. Seed the `RandomCoin` from `Word::from(NoteScript::from_package(note_package.as_ref())?.root())` (see Step 6 and [counter_test.rs](../../../integration/tests/counter_test.rs)).
 
-### Building Notes from `.masp` Packages
+The serial number is what makes a note unique, and the RNG source differs between the deterministic test path and the real-client path:
 
-When a test or binary needs full control over the note (custom storage Felts, deterministic serial number, P2ID-style metadata, or a real-client publish + consume flow), build directly from a compiled `.masp` package. The canonical pipeline is `NoteScript::from_package(package.as_ref())` paired with `NoteBuilder::new(sender_id, &mut RandomCoin::new(note_script.root())).package((*package).clone()).note_type(...).tag(...).add_assets(...).note_storage(...).serial_number(...).build()`. Project-template's own [counter_test.rs](../../../integration/tests/counter_test.rs) follows this same shape with `NoteBuilder` directly.
+- **Deterministic test path**: seed the `RandomCoin` from the note-script root and omit `.serial_number(...)`, letting `NoteBuilder` derive the serial deterministically from `RandomCoin::new(Word::from(note_script.root()))`. Used when seeding `MockChainBuilder` with a freshly-built note. See [counter_test.rs](../../../integration/tests/counter_test.rs).
+- **Real-client path**: pass the client's RNG directly (`NoteBuilder::new(sender.id(), client.rng())`) so each note gets a fresh serial, then publish it with a real `TransactionRequestBuilder`. See [integration/src/bin/increment_count.rs](../../../integration/src/bin/increment_count.rs), which builds the note with `client.rng()` + `.tag(0)`, publishes it via `TransactionRequestBuilder::new().own_output_notes(vec![note.clone()]).build()?`, and consumes it via `.input_notes([(note.clone(), None)]).build()?`. For the surrounding client setup (CLI side), see the `miden-client-cli` skill.
 
-The miden-bank tutorial codifies this as two helpers built on top of `NoteScript::from_package` + `NoteBuilder`:
-
-- **Real-client path** (`create_note_from_package`): calls `client.rng().draw_word()` and threads it through `NoteBuilder::serial_number(...)` for a fresh per-note serial. Used when the note will be published via a real `TransactionRequestBuilder`. See [miden-bank helpers.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/src/helpers.rs) (`create_note_from_package`).
-- **Deterministic test path** (`create_testing_note_from_package`): omits `serial_number(...)`, letting `NoteBuilder` derive the serial deterministically from `RandomCoin::new(note_script.root())`. Used when seeding `MockChainBuilder` with a freshly-built note. See [miden-bank helpers.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/src/helpers.rs) (`create_testing_note_from_package`).
-
-Both helpers take a `NoteCreationConfig` with four fields: `note_type: NoteType`, `tag: NoteTag`, `assets: NoteAssets`, `storage: Vec<Felt>`. See [miden-bank helpers.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/src/helpers.rs) (`NoteCreationConfig` struct + `Default` impl). To drive a cross-component note (see `rust-sdk-patterns` "Cross-Component Note Pattern"), populate `NoteCreationConfig.storage` with the serialized Felt representation of the typed note struct's fields in declaration order; the `#[note]` macro deserializes that slice into `self` before the script runs.
-
-Test-side example: see [miden-bank withdraw_test.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/tests/withdraw_test.rs) for a storage vector reaching the note via `NoteCreationConfig { storage, ..Default::default() }` and the seeded `MockChainBuilder.add_output_note(RawOutputNote::Full(...))` call before `builder.build()`.
-
-Binary-side example: see [miden-bank deposit.rs](https://github.com/0xMiden/tutorials/blob/main/examples/miden-bank/integration/src/bin/deposit.rs) for `build_project_in_dir(...)` to produce the `.masp` package, `create_note_from_package(...)` to assemble the note, then `TransactionRequestBuilder::own_output_notes(vec![note.clone()])` and `input_notes([(note.clone(), None)])` to publish and consume. For the surrounding client setup (CLI side), see the `miden-client-cli` skill.
+To drive a **cross-component note** (see the `rust-sdk-patterns` "Cross-Component Note Pattern"), populate the note's `note_storage(...)` with the serialized Felt representation of the typed `#[note]` struct's fields in declaration order; the `#[note]` macro deserializes that slice into `self` before the script runs. The increment note carries no such storage — its `#[note_script] fn run(self, _arg: Word, account: &mut Wallet)` simply calls `account.get_count()` / `account.increment_count()`.
 
 ## Asset-Bearing Note Example
 
 To create a note that carries fungible assets in tests:
 
-1. Create a `FungibleAsset` from a faucet ID and amount.
-2. Seed a `RandomCoin` from `NoteScript::from_package(note_package.as_ref())?.root()`.
-3. Pass the asset into `NoteBuilder::add_assets(...)` and any note inputs into `note_storage(...)`.
+1. Create a `FungibleAsset` from a faucet ID and amount, e.g. `FungibleAsset::new(faucet.id(), 50)?`, and wrap into `NoteAssets::new(vec![Asset::Fungible(asset)])?` (or pass via `NoteBuilder::add_assets`).
+2. Seed a `RandomCoin` from `Word::from(NoteScript::from_package(note_package.as_ref())?.root())` (the conversion turns the `NoteScriptRoot` into the `Word` that `RandomCoin::new` expects).
+3. Pass the asset into `NoteBuilder::add_assets(...)` and any note inputs into `note_storage(...)?`. `note_storage` wants `Item = Felt`; build each input with the infallible `Felt::from(_u32)` for in-range literals (not `Felt::new(u64)`, which is fallible), or `Felt::new_unchecked(n)` for u64 inputs (see Step 6).
 4. Finish with `.package((*note_package).clone()).build()?`.
 
 The faucet must be set up first (see Step 3) and the sender wallet must hold sufficient assets (see Step 2).
 
 ## Key Dependencies
 
-See [integration/Cargo.toml](../../../integration/Cargo.toml) for the current dependency versions used in this project.
+See [integration/Cargo.toml](../../../integration/Cargo.toml) for the exact versions. The integration crate depends on `cargo-miden = "0.9"` (its `build_project_in_dir` helper calls `cargo_miden::run`) alongside the 0.15 line — `miden-client`, `miden-standards`, `miden-testing`, and `miden-client-sqlite-store` at `0.15`, plus `miden-mast-package = "0.23"` — with no git-rev/branch pins. The contracts it builds depend on the guest SDK `miden = "0.13"` and compile with the released compiler v0.9.0.
 
 ## Validation Checklist
 
 - [ ] Test function is `async` and uses `#[tokio::test]`
-- [ ] Storage slot names follow `package_or_name::component_struct::field_name` pattern
+- [ ] Auth uses `AuthSchemeId::Falcon512Poseidon2` (or the equivalent `AuthScheme::Falcon512Poseidon2` — both name the same protocol enum)
+- [ ] `AccountBuilder` uses `.account_type(AccountType::Public | ::Private)` and no `.storage_mode(...)` / no `AccountStorageMode`
+- [ ] Storage slot names follow `<package_name>::<interface_segment>::<field_name>` (bare package name, `[lib].namespace` interface segment, e.g. `counter_account::counter_contract::count_map`)
+- [ ] Map slots seeded per-entry via `InitStorageData::insert_map_entry(slot, key, value)`; value slots without a schema default seeded via `InitStorageData::insert_value(StorageValueName::from_slot_name(&slot), ..)` with a `Word` (e.g. `Word::default()`), not a bare integer (numeric `Into<WordValue>` yields an atomic string, not a felt-positioned word)
 - [ ] All contracts built before account/note creation
-- [ ] Account storage seeded via `InitStorageData`
+- [ ] `NoteScript::root()` converted with `Word::from(...)` before seeding `RandomCoin`
+- [ ] Note-storage felts built with infallible `Felt::from(_u32)` or `Felt::new_unchecked(_u64)` (`Felt::new(u64)` returns `Result`, so a bare `[Felt::new(..)]` array does not satisfy `Item = Felt`)
+- [ ] `Note::new(...)` is passed a `PartialNoteMetadata` (not `NoteMetadata`)
+- [ ] `kind = "tx-script"` packages built with `from_parts` / a `build_tx_script_from_package`-style helper (not `from_package`/`unwrap_program`, which error/panic on them)
 - [ ] `prove_next_block()` called after `add_pending_executed_transaction()`
-- [ ] Post-block assertions read state from `mock_chain.committed_account(...)` or other committed chain views
+- [ ] Post-block assertions read state from `mock_chain.committed_account(...)` (or `account.apply_delta(...)` is called when reusing an in-memory `Account` across transactions)
 - [ ] Notes added to `MockChainBuilder` via `add_output_note(RawOutputNote::Full(...))` before `build()`
 - [ ] Faucet set up before creating assets


### PR DESCRIPTION
## Overview

This PR brings the six `.claude/skills` files that overlap with `0xMiden/agent-tools` up to their Miden v0.15 state, so the template's skill guidance matches the code that #51 already migrated to v0.15. It ports the v0.15 substance from the agent-tools skills (source-grounded, Codex-audited) while keeping every example, path, and cross-link that is specific to this template. Doc-only: no code, config, or test changes.

Note on base: the sync was originally planned to stack on `migrate-protocol-v015`, but #51 has since merged, so this targets `main` directly. The skill files are identical on both, so the diff is the same either way.

## Key Changes

Six skills updated to v0.15, each keeping the template's own worked examples (the counter contract + increment note, the `contracts/` and `integration/` paths), rather than agent-tools' bank-account examples:

| Skill | Ported (v0.15 substance) | Preserved (template-specific) | Dropped |
|---|---|---|---|
| `miden-concepts` | Note `NoteStorage` (`Vec<Felt>`); fallible `Felt::new`; standard components (`BasicWallet`, `FungibleFaucet::builder()`, `NoAuth`, `AuthSingleSig`/`Falcon512Poseidon2`) | Section structure; `rust-sdk-pitfalls` cross-link | JS/React SDK asides and their non-existent `frontend-pitfalls` link |
| `rust-sdk-pitfalls` | 16-felt call boundary; three-part component macro; v0.15 slot-name derivation; two-word `Asset`; `note::build_recipient`; `NoteType` 1-bit encoding; `active_note::get_storage()` | Felt-arithmetic and `as_canonical_u64` security rules; counter examples; `contracts/` links | "old / removed / gone" migration framing |
| `rust-sdk-source-guide` | Repo map + tags (protocol `v0.15.3`, client `v0.15.2`, compiler `v0.9.0`, `miden 0.13`, `cargo-miden 0.9`); error-translation table | Template test command `cargo test -p integration --release`; repo-exploration workflow | multi-repo `make test` / `nextest` guidance not relevant here |
| `local-node-validation` | Split node topology (validator / sequencer / ntx-builder / prover); `scripts/start-test-node.sh`; `.sqlite_store` extension-trait footgun; connect-time version negotiation | `integration/src` paths; `setup_local_client`; counter / `increment_count` example; port `57291`; `miden-client-cli` cross-link | pre-v0.15 accept-header / genesis-cache item |
| `rust-sdk-patterns` | Three-part component macro; `#[account(...)]` wrapper for notes and tx-scripts; slot-name derivation; corrected native-function signatures; `Asset::new`; fallible `Felt::new`; two-place cross-component deps | Counter contract + increment note as the sole worked example; all namespaces and paths; the `p2id-note` compiler example | all `miden-bank` example links; the `crate::bindings::Account` example |
| `rust-sdk-testing-patterns` | v0.15 slot naming; faucet setup; `PartialNoteMetadata` / `Note::new`; tx-script `from_parts`; `InitStorageData` seeding footgun; `NoteScript::root()` newtype | `counter_test.rs` flow verbatim (MockChain builder, `insert_map_entry`, `add_account_from_builder`, `prove_next_block`, `get_map_item`); `helpers.rs` / `increment_count.rs` references | migration framing |

## Rationale

- The skills still described the pre-v0.15 SDK while the code (via #51) had already moved to v0.15, so guidance and code were out of sync.
- agent-tools teaches these patterns with its miden-bank tutorial; this template teaches with its counter contract. I re-expressed every v0.15 point using the counter example instead of importing bank code, so the snippets match the contracts actually in this repo. Counter references stay high in the two counter-centric skills (`rust-sdk-patterns`: 21, `rust-sdk-testing-patterns`: 29) with zero bank code in either.
- `rust-sdk-source-guide` still points at the external `tutorials/examples/miden-bank` app, because mapping external repos for advanced patterns is that skill's whole purpose and those pointers were already present in the template (this is not the counter being clobbered by bank code).

## Notes

- Every counter and test snippet was checked against the actual v0.15 source in `contracts/` and `integration/`; version pins are the v0.15 set (`miden = "0.13"`, `cargo-miden = "0.9"`, the `0.15` client stack, protocol `v0.15.3`, compiler `v0.9.0`), with no stray `0.14` literals.
- Scope is exactly the six `SKILL.md` files. `miden-client-cli` and every other skill are untouched.

Follows #51 (now merged into `main`).
