### PR TITLE
docs: correct miden-client pin referenced in miden-client-cli skill

### DIFF
--- a/.claude/skills/miden-client-cli/SKILL.md
+++ b/.claude/skills/miden-client-cli/SKILL.md
@@ -46,7 +46,7 @@ Subsequent commands operate against that config. For localhost workflows, pair t
 
 ## Canonical Command Reference
 
-Follow the canonical in-repo references on `0xMiden/miden-client` (the active line, which matches project-template's pinned `miden-client = "0.14"`). The `miden-docs` site (`0xMiden.github.io/miden-docs/...`) is not used here because those URLs are not stable.
+Follow the canonical in-repo references on `0xMiden/miden-client` (the active line, which matches project-template's pinned `miden-client = "0.15"`). The `miden-docs` site (`0xMiden.github.io/miden-docs/...`) is not used here because those URLs are not stable.
 
 - CLI Reference: [`docs/external/src/rust-client/cli/index.md`](https://github.com/0xMiden/miden-client/blob/main/docs/external/src/rust-client/cli/index.md)
 - CLI Configuration: [`docs/external/src/rust-client/cli/cli-config.md`](https://github.com/0xMiden/miden-client/blob/main/docs/external/src/rust-client/cli/cli-config.md)


### PR DESCRIPTION
The `miden-client-cli` skill says project-template pins `miden-client = "0.14"`:

```
.claude/skills/miden-client-cli/SKILL.md:49
Follow the canonical in-repo references on `0xMiden/miden-client` (the active
line, which matches project-template's pinned `miden-client = "0.14"`).
```

`integration/Cargo.toml` on `main` pins `0.15`:

```
miden-client = { version = "0.15", features = ["tonic"] }
miden-client-sqlite-store = { version = "0.15", package = "miden-client-sqlite-store" }
miden-standards = { version = "0.15", features = ["testing"] }
miden-testing = "0.15"
```

The skill exists to send an agent to the right upstream reference, so the stale
number points it at the wrong SDK line. This changes that one occurrence to
`0.15`; `grep -rn '0\.14'` finds no others outside `Cargo.lock`.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
