### PR TITLE
fix: remove stale config file from README tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ miden-project/
 ├── integration/                 # Integration crate (scripts + tests)
 │   ├── src/
 │   │   ├── bin/                 # Rust binaries for on-chain interactions
-│   │   ├── config.rs            # Temporary config file (do not modify!)
 │   │   ├── helpers.rs           # Temporary helper file (do not modify!)
 │   │   └── lib.rs
 │   └── tests/                   # Test files


### PR DESCRIPTION
## Summary

Removes the stale `integration/src/config.rs` entry from the README project tree.

Fixes #57.

## Why

The current template does not include `integration/src/config.rs`; `integration/src` contains `bin/`, `helpers.rs`, and `lib.rs`. The README tree should match the files users actually get from the template.

## Testing

- `git diff --check`

This is a docs-only change, so I did not run the Rust test suite.